### PR TITLE
Feature/action link arrow

### DIFF
--- a/src/App/Documentation/components/Panel/index.js
+++ b/src/App/Documentation/components/Panel/index.js
@@ -1,5 +1,4 @@
 import React from "react";
-import PrismCode from "react-prism";
 
 import { ComponentPreview, DocContainer, Property } from "#";
 import PanelComponent from "@/Panel";

--- a/src/less/components/action-link.less
+++ b/src/less/components/action-link.less
@@ -1,6 +1,7 @@
 a.action-link {
     position: relative;
-    display: block;
+    display: flex;
+    align-items: center;
     padding: 1rem;
     padding-left: 1.5rem;
     border: 0;
@@ -23,12 +24,13 @@ a.action-link {
 
         position: absolute;
         right: 1rem;
+        margin: 0;
         color: @brand-primary;
         font-size: 32px;
     }
 
-    .material-icons {
-        color: @brand-primary;
-        font-size: 1.5rem;
+    // Temporary solution until DG-323 (https://payexjira.atlassian.net/secure/RapidBoard.jspa?rapidView=80&projectKey=DG&modal=detail&selectedIssue=DG-323) is solved [AW].
+    > * {
+        margin-right: 0.5rem;
     }
 }

--- a/src/less/components/action-link.less
+++ b/src/less/components/action-link.less
@@ -18,10 +18,13 @@ a.action-link {
     }
 
     &:after {
-        content: "▶";
+        content: "arrow_right";
+        .material-icons-styling();
+
         position: absolute;
         right: 1rem;
         color: @brand-primary;
+        font-size: 32px;
     }
 
     .material-icons {

--- a/src/less/components/badge.less
+++ b/src/less/components/badge.less
@@ -3,6 +3,7 @@
     padding: 0 0.5em; /* stylelint-disable-line */ /* Using em for variable padding based on font-size of badge [AW] */
     border-radius: 2rem;
     font-size: 85%;
+    line-height: 1;
 
     each(@badge-list, .(@color, @name) {
         &.badge-@{name} {


### PR DESCRIPTION
.action-link uses a plain text arrow which renders differently on different browsers and operating systems.
By using .material-icons instead we can ensure a consistent look and feel across all platforms.