### PR TITLE
Fix issue with sheet.close and sheet.open

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,4 +8,6 @@
 
 ### Fixed
 
+- Fixed issue with px.sheet.open and px.sheet.close
+
 ### Removed

--- a/src/App/Documentation/components/Sheet/__snapshots__/index.test.js.snap
+++ b/src/App/Documentation/components/Sheet/__snapshots__/index.test.js.snap
@@ -453,9 +453,9 @@ exports[`Documentation: Sheet JavascriptMethods renders 1`] = `
 exports[`Documentation: Sheet RequireAction renders 1`] = `
 <Fragment>
   <h2
-    id="example"
+    id="require-action"
   >
-    Example
+    Require action
   </h2>
   <p>
     To disable the listener responsible for closing the sheet when a user clicks outside, add 

--- a/src/App/Documentation/components/Sheet/index.js
+++ b/src/App/Documentation/components/Sheet/index.js
@@ -58,7 +58,7 @@ const Example = () => (
 
 const RequireAction = () => (
     <>
-        <h2 id="example">Example</h2>
+        <h2 id="require-action">Require action</h2>
         <p>
             To disable the listener responsible for closing the sheet when a user clicks outside, add <Property value="data-require-action" /> to your Sheet.
         </p>

--- a/src/px-script/main/sheet/index.js
+++ b/src/px-script/main/sheet/index.js
@@ -21,14 +21,12 @@ class Sheet {
 
         if (this.closeIcon) {
             this.closeIcon.addEventListener("click", e => {
-                handleScrollbar();
                 e.preventDefault();
                 this.close();
             });
         }
 
         if (this.isOpen) {
-            handleScrollbar();
             this._el.classList.add("d-block");
             document.body.classList.add("sheet-open");
         }
@@ -37,7 +35,6 @@ class Sheet {
         if (!this.requireAction) {
             this._el.addEventListener("click", e => {
                 if (e.target.classList.contains("sheet-open")) {
-                    handleScrollbar();
                     this.close();
                 }
             });
@@ -83,6 +80,7 @@ class Sheet {
     }
 
     close () {
+        handleScrollbar();
         this.isOpen = false;
         this._el.classList.remove("sheet-open");
         document.body.classList.remove("sheet-open");
@@ -140,7 +138,6 @@ const _addEscListener = () => {
     // Close sheet on esc
     document.addEventListener("keydown", e => {
         if (e.keyCode === 27 && document.body.classList.contains("sheet-open")) {
-            handleScrollbar();
             _sheets.forEach(sheet => sheet.isOpen ? sheet.close() : null);
         }
     });
@@ -152,14 +149,18 @@ const close = id => {
     _sheets.forEach(d => d.id === id ? sheet = d : null);
 
     try {
+        if (!sheet.isOpen) {
+            console.warn(`sheet.close: Sheet with id "${id}" is not open`);
+
+            return false;
+        }
+
         sheet.close();
     } catch (e) {
         console.warn(`sheet.close: No sheet with id "${id}" found.`);
 
         return false;
     }
-
-    handleScrollbar();
 
     return sheet;
 };
@@ -170,6 +171,12 @@ const open = id => {
     _sheets.forEach(d => d.id === id ? sheet = d : null);
 
     try {
+        if (sheet.isOpen) {
+            console.warn(`sheet.open: Sheet with id "${id}" is open`);
+
+            return false;
+        }
+
         sheet.open();
     } catch (e) {
         console.warn(`sheet.open: No sheet with id "${id}" found.`);

--- a/src/px-script/main/sheet/index.test.js
+++ b/src/px-script/main/sheet/index.test.js
@@ -89,6 +89,13 @@ describe("px-script: sheet", () => {
             expect(sheet.init()).toBeNull();
             expect(console.warn).toHaveBeenCalled();
         });
+
+        it("returns null if the passed id is not found and prints a warning", () => {
+            console.warn = jest.fn();
+
+            expect(sheet.init("invalid-id")).toBeNull();
+            expect(console.warn).toHaveBeenCalled();
+        });
     });
 
     it("button with attribute 'data-sheet-open' pointing to the correct id opens corresponding sheet", () => {
@@ -255,6 +262,25 @@ describe("px-script: sheet", () => {
             expect(renderedSheet.classList).not.toContain("sheet-open");
             expect(document.body.classList).not.toContain("sheet-open");
         });
+
+        it("does not open sheet when the passed sheet is already open and prints a warning to the console", () => {
+            console.warn = jest.fn();
+            ReactDOM.render(<OpenSheet id="demo-sheet" />, div);
+
+            const renderedSheet = document.querySelector(".sheet");
+
+            sheet.init();
+            expect(renderedSheet.classList).toContain("d-block");
+            expect(renderedSheet.classList).toContain("sheet-open");
+            expect(document.body.classList).toContain("sheet-open");
+
+            sheet.open("demo-sheet");
+
+            expect(console.warn).toHaveBeenCalledWith("sheet.open: Sheet with id \"demo-sheet\" is open");
+            expect(renderedSheet.classList).toContain("d-block");
+            expect(renderedSheet.classList).toContain("sheet-open");
+            expect(document.body.classList).toContain("sheet-open");
+        });
     });
 
     describe("sheet.close", () => {
@@ -295,6 +321,25 @@ describe("px-script: sheet", () => {
             expect(renderedSheet.classList).toContain("d-block");
             expect(renderedSheet.classList).toContain("sheet-open");
             expect(document.body.classList).toContain("sheet-open");
+        });
+
+        it("does not close sheet when the passed sheet is close and prints a warning to the console", () => {
+            console.warn = jest.fn();
+            ReactDOM.render(<Sheet id="demo-sheet" />, div);
+
+            const renderedSheet = document.querySelector(".sheet");
+
+            sheet.init();
+            expect(renderedSheet.classList).not.toContain("d-block");
+            expect(renderedSheet.classList).not.toContain("sheet-open");
+            expect(document.body.classList).not.toContain("sheet-open");
+
+            sheet.close("demo-sheet");
+
+            expect(console.warn).toHaveBeenCalledWith("sheet.close: Sheet with id \"demo-sheet\" is not open");
+            expect(renderedSheet.classList).not.toContain("d-block");
+            expect(renderedSheet.classList).not.toContain("sheet-open");
+            expect(document.body.classList).not.toContain("sheet-open");
         });
     });
 


### PR DESCRIPTION
The two functions could be called when the given sheet was in the correct state. Updated px.sheet tests.