### PR TITLE
Bugfix/px script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,5 +12,6 @@
 
 - Fixed issue with esc event listener for topbar nav menu.
 - Updated animation for mobile topbar to make it smoother.
+- Fixed issue with px.sheet.init() returning an empty array.
 
 ### Removed

--- a/src/App/Documentation/components/Expandable/index.js
+++ b/src/App/Documentation/components/Expandable/index.js
@@ -1,8 +1,9 @@
 import React, { useEffect } from "react";
 
 import { ComponentPreview, DocContainer, Property } from "#";
-import expandable from "$/px-script/main/expandable";
 import ExpandableComponent from "@/Expandable";
+
+const { expandable } = window.px;
 
 const items = [
     {

--- a/src/App/index.js
+++ b/src/App/index.js
@@ -6,7 +6,8 @@ import Loadable from "react-loadable";
 import Footer from "@/Footer";
 import AppHeader from "./AppHeader";
 import { LoadingComponent } from "./utils";
-import { topbar } from "../px-script/main";
+
+const { topbar } = window.px;
 
 const BASENAME = process.env.basename || "/";
 const history = createBrowserHistory({ basename: BASENAME });
@@ -67,7 +68,7 @@ class App extends Component {
     }
 
     componentDidMount () {
-        topbar.init(0);
+        topbar.init();
     }
 
     render () {

--- a/src/App/utils/LoadingComponent.js
+++ b/src/App/utils/LoadingComponent.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import Loader from "@/Loader";
-import { loader } from "$/px-script/main";
+
+const { loader } = window.px;
 
 class LoadingComponent extends Component {
     componentDidMount () {

--- a/src/px-script/main/index.js
+++ b/src/px-script/main/index.js
@@ -42,7 +42,7 @@ const px = {
     validation
 };
 
-window.px = !window.px ? px : Object.assign(px, window.px);
+window.px = window.px ? Object.assign(px, window.px) : px;
 
 if (!window.stopPx) {
     document.addEventListener("DOMContentLoaded", () => {

--- a/src/px-script/main/index.js
+++ b/src/px-script/main/index.js
@@ -42,7 +42,7 @@ const px = {
     validation
 };
 
-window.px = px;
+window.px = !window.px ? px : Object.assign(px, window.px);
 
 if (!window.stopPx) {
     document.addEventListener("DOMContentLoaded", () => {

--- a/src/px-script/main/topbar/index.js
+++ b/src/px-script/main/topbar/index.js
@@ -91,7 +91,7 @@ const init = id => {
         const navMenuObjects = [...topbars].map(topbar => {
             const navMenuQuery = topbar.querySelector(SELECTORS.TOPBARNAV);
 
-            navMenuQuery ? _createTopbar(topbar, navMenuQuery) : null;
+            return navMenuQuery ? _createTopbar(topbar, navMenuQuery) : null;
         });
 
         _addEscListener();

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = (env, argv) => {
     const config = {
         entry: {
             "px-script": ["@babel/polyfill", "./src/px-script/main/index.js"],
-            "px.dashboard": "./src/px-script/dashboard/index.js",
+            "px-dashboard": "./src/px-script/dashboard/index.js",
             app: ["@babel/polyfill/noConflict", "./src/index.js"]
         },
         resolve: {


### PR DESCRIPTION
- Fix sheet.init returning an empty array.
- Remove px-script imports from documentation.
- Fix issue where px-script would overwrite px-dashboard.
- Change dashboard entry naming to make naming consistent.