### PR TITLE
Remove h4-h6 and small in heading from docs

### DIFF
--- a/src/App/Documentation/core/Typography/__snapshots__/index.test.js.snap
+++ b/src/App/Documentation/core/Typography/__snapshots__/index.test.js.snap
@@ -184,15 +184,6 @@ exports[`Core: Typography Headings renders 1`] = `
     <h3>
       Heading h3
     </h3>
-    <h4>
-      Heading h4
-    </h4>
-    <h5>
-      Heading h5
-    </h5>
-    <h6>
-      Heading h6
-    </h6>
   </ComponentPreview>
   <p>
     The classes 
@@ -224,21 +215,6 @@ exports[`Core: Typography Headings renders 1`] = `
       className="h3"
     >
       .h3 heading
-    </p>
-    <p
-      className="h4"
-    >
-      .h4 heading
-    </p>
-    <p
-      className="h5"
-    >
-      .h5 heading
-    </p>
-    <p
-      className="h6"
-    >
-      .h6 heading
     </p>
   </ComponentPreview>
 </Fragment>
@@ -399,38 +375,6 @@ exports[`Core: Typography Lead renders 1`] = `
 </Fragment>
 `;
 
-exports[`Core: Typography Small renders 1`] = `
-<Fragment>
-  <h2
-    id="small"
-  >
-    Small
-  </h2>
-  <p>
-    Use the 
-    <PrismCode
-      className="language-html"
-      component="code"
-    >
-      &lt;small&gt;&lt;/small&gt;
-    </PrismCode>
-     tags to create a secondary heading within a heading tag or class.
-  </p>
-  <ComponentPreview
-    codeFigure={true}
-    language="html"
-    showCasePanel={true}
-  >
-    <h2>
-      Main heading 
-      <small>
-        with a faded secondary heading
-      </small>
-    </h2>
-  </ComponentPreview>
-</Fragment>
-`;
-
 exports[`Core: Typography Text Utilities renders 1`] = `
 <Fragment>
   <h2
@@ -461,7 +405,6 @@ exports[`Core: Typography renders 1`] = `
   </p>
   <Fonts />
   <Headings />
-  <Small />
   <Lead />
   <Inline />
   <TextUtilities />

--- a/src/App/Documentation/core/Typography/index.js
+++ b/src/App/Documentation/core/Typography/index.js
@@ -19,28 +19,12 @@ const Headings = () => (
             <h1>Heading h1</h1>
             <h2>Heading h2</h2>
             <h3>Heading h3</h3>
-            <h4>Heading h4</h4>
-            <h5>Heading h5</h5>
-            <h6>Heading h6</h6>
         </ComponentPreview>
         <p>The classes <Property value=".h1" /> through <Property value=".h6" /> are also available, for when you want to match the font styling of a heading but cannot use the associated HTML element.</p>
         <ComponentPreview language="html" showCasePanel codeFigure>
             <p className="h1">.h1 heading</p>
             <p className="h2">.h2 heading</p>
             <p className="h3">.h3 heading</p>
-            <p className="h4">.h4 heading</p>
-            <p className="h5">.h5 heading</p>
-            <p className="h6">.h6 heading</p>
-        </ComponentPreview>
-    </>
-);
-
-const Small = () => (
-    <>
-        <h2 id="small">Small</h2>
-        <p>Use the <PrismCode className="language-html">{"<small></small>"}</PrismCode> tags to create a secondary heading within a heading tag or class.</p>
-        <ComponentPreview language="html" showCasePanel codeFigure>
-            <h2>Main heading <small>with a faded secondary heading</small></h2>
         </ComponentPreview>
     </>
 );
@@ -141,7 +125,6 @@ const Typography = () => (
         <p className="lead">Documentation and examples for Swedbank Pay DesignGuide typography.</p>
         <Fonts />
         <Headings />
-        <Small />
         <Lead />
         <Inline />
         <TextUtilities />
@@ -153,4 +136,4 @@ const Typography = () => (
 export default Typography;
 
 /* For testing */
-export { Fonts, Headings, Small, Lead, Inline, TextUtilities, Abbreviations, Blockquotes };
+export { Fonts, Headings, Lead, Inline, TextUtilities, Abbreviations, Blockquotes };

--- a/src/App/Documentation/core/Typography/index.test.js
+++ b/src/App/Documentation/core/Typography/index.test.js
@@ -2,7 +2,7 @@
 import React from "react";
 import { shallow } from "enzyme";
 
-import Typography, { Fonts, Headings, Small, Lead, Inline, TextUtilities, Abbreviations, Blockquotes } from "./index";
+import Typography, { Fonts, Headings, Lead, Inline, TextUtilities, Abbreviations, Blockquotes } from "./index";
 
 describe("Core: Typography", () => {
     it("is defined", () => {
@@ -34,18 +34,6 @@ describe("Core: Typography", () => {
 
         it("renders", () => {
             const wrapper = shallow(<Headings />);
-
-            expect(wrapper).toMatchSnapshot();
-        });
-    });
-
-    describe("Small", () => {
-        it("is defined", () => {
-            expect(Small).toBeDefined();
-        });
-
-        it("renders", () => {
-            const wrapper = shallow(<Small />);
 
             expect(wrapper).toMatchSnapshot();
         });

--- a/src/less/core/typography.less
+++ b/src/less/core/typography.less
@@ -24,7 +24,7 @@ h1,
 .h1 {
     font-size: 1.5rem;
     font-family: @font-swedbank-headline;
-    font-weight: 700;
+    font-weight: bold;
     line-height: 2rem;
 
     .material-icons {
@@ -37,7 +37,7 @@ h2,
 .h2 {
     font-size: 1.25rem;
     font-family: @font-swedbank-headline;
-    font-weight: 700;
+    font-weight: bold;
     line-height: 1.5rem;
 
     .material-icons {
@@ -48,27 +48,44 @@ h2,
 
 h3,
 .h3 {
-    font-weight: 700;
+    font-size: 1rem;
+    font-weight: bold;
     line-height: 1.5rem;
 
     .material-icons {
+        font-size: 1rem;
         line-height: 1.5rem;
     }
 }
 
 h4,
 .h4 {
-    font-weight: 700;
+    font-weight: bold;
+    font-size: 0.9rem;
+
+    .material-icons {
+        font-size: 0.9rem;
+    }
 }
 
 h5,
 .h5 {
-    font-weight: 400;
+    font-weight: bold;
+    font-size: 0.8rem;
+
+    .material-icons {
+        font-size: 0.8rem;
+    }
 }
 
 h6,
 .h6 {
-    font-weight: 400;
+    font-weight: bold;
+    font-size: 0.7rem;
+
+    .material-icons {
+        font-size: 0.7rem;
+    }
 }
 
 //
@@ -185,6 +202,36 @@ blockquote,
         .material-icons {
             font-size: 1.25rem;
             line-height: 1.5rem;
+        }
+    }
+
+    h4,
+    .h4 {
+        font-size: 1rem;
+        font-weight: bold;
+
+        .material-icons {
+            font-size: 1rem;
+        }
+    }
+
+    h5,
+    .h5 {
+        font-size: 0.9rem;
+        font-weight: bold;
+
+        .material-icons {
+            font-size: 0.9rem;
+        }
+    }
+
+    h6,
+    .h6 {
+        font-size: 0.8rem;
+        font-weight: bold;
+
+        .material-icons {
+            font-size: 0.8rem;
         }
     }
 

--- a/src/less/core/typography.less
+++ b/src/less/core/typography.less
@@ -61,30 +61,30 @@ h3,
 h4,
 .h4 {
     font-weight: bold;
-    font-size: 0.9rem;
+    font-size: 1rem;
 
     .material-icons {
-        font-size: 0.9rem;
+        font-size: 1rem;
     }
 }
 
 h5,
 .h5 {
     font-weight: bold;
-    font-size: 0.8rem;
+    font-size: 1rem;
 
     .material-icons {
-        font-size: 0.8rem;
+        font-size: 1rem;
     }
 }
 
 h6,
 .h6 {
     font-weight: bold;
-    font-size: 0.7rem;
+    font-size: 1rem;
 
     .material-icons {
-        font-size: 0.7rem;
+        font-size: 1rem;
     }
 }
 
@@ -202,36 +202,6 @@ blockquote,
         .material-icons {
             font-size: 1.25rem;
             line-height: 1.5rem;
-        }
-    }
-
-    h4,
-    .h4 {
-        font-size: 1rem;
-        font-weight: bold;
-
-        .material-icons {
-            font-size: 1rem;
-        }
-    }
-
-    h5,
-    .h5 {
-        font-size: 0.9rem;
-        font-weight: bold;
-
-        .material-icons {
-            font-size: 0.9rem;
-        }
-    }
-
-    h6,
-    .h6 {
-        font-size: 0.8rem;
-        font-weight: bold;
-
-        .material-icons {
-            font-size: 0.8rem;
         }
     }
 


### PR DESCRIPTION
Removed h4-h6 from documentation and got rid of the `<small>` in a heading example.