### PR TITLE
Feature/dialog tab order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Added .dialog-header and .dialog-footer to the dialog component.
 - Added tab lock to dialog making it so you can't tab out of the dialog until an option is clicked.
+- Added aria labels to dialog documentation to show an example of how to use dialog accessibly.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@
 
 ### Added
 
+- Added .dialog-header and .dialog-footer to the dialog component.
+- Added tab lock to dialog making it so you can't tab out of the dialog until an option is clicked.
+
 ### Changed
+
+- Made it so you don't have to include the ID on the close buttons inside Dialog.
+- Changed the close button in dialog to be a button instead of an icon.
 
 ### Fixed
 

--- a/src/App/Documentation/components/Dialog/__snapshots__/index.test.js.snap
+++ b/src/App/Documentation/components/Dialog/__snapshots__/index.test.js.snap
@@ -37,7 +37,7 @@ exports[`Documentation: Dialog Example renders 1`] = `
             
 				
             <Icon
-              icon="close"
+              type="close"
             />
             
 			
@@ -60,7 +60,7 @@ exports[`Documentation: Dialog Example renders 1`] = `
 
           <button
             className="btn btn-guiding"
-            data-dialog-close="demo-dialog"
+            data-dialog-close={true}
             type="button"
           >
             Cancel

--- a/src/App/Documentation/components/Dialog/__snapshots__/index.test.js.snap
+++ b/src/App/Documentation/components/Dialog/__snapshots__/index.test.js.snap
@@ -17,7 +17,11 @@ exports[`Documentation: Dialog Example renders 1`] = `
       data-dialog-open="demo-dialog"
       type="button"
     >
+      
+
       Open dialog
+      
+
     </button>
     <Dialog
       diaHeader="Delete item 456?"

--- a/src/App/Documentation/components/Dialog/__snapshots__/index.test.js.snap
+++ b/src/App/Documentation/components/Dialog/__snapshots__/index.test.js.snap
@@ -19,67 +19,17 @@ exports[`Documentation: Dialog Example renders 1`] = `
     >
       Open dialog
     </button>
-    <div
-      className="dialog"
-      id="demo-dialog"
+    <Dialog
+      diaHeader="Delete item 456?"
+      diaId="demo-dialog"
     >
-      <section>
-        <header>
-          <h4>
-            Delete item 456?
-          </h4>
-          
-
-          <a
-            className="dialog-close"
-            href="#"
-          >
-            
-				
-            <Icon
-              type="close"
-            />
-            
-			
-          </a>
-          
-		
-        </header>
-        <div
-          className="dialog-body"
-        >
-          <p>
-            Are you sure you want to permanently delete the item 
-            <i>
-              German Swashbuckle (456)?
-            </i>
-          </p>
-        </div>
-        <footer>
-          
-
-          <button
-            className="btn btn-guiding"
-            data-dialog-close={true}
-            type="button"
-          >
-            Cancel
-          </button>
-          
-
-          <button
-            className="btn btn-destructive"
-            type="button"
-          >
-            Delete
-          </button>
-          
-
-        </footer>
-      </section>
-    </div>
-    
-
+      <p>
+        Are you sure you want to permanently delete the item 
+        <i>
+          German Swashbuckle (456)?
+        </i>
+      </p>
+    </Dialog>
   </ComponentPreview>
 </Fragment>
 `;

--- a/src/App/Documentation/components/Dialog/index.js
+++ b/src/App/Documentation/components/Dialog/index.js
@@ -1,8 +1,9 @@
-import React, { Component } from "react";
+import React, { useEffect } from "react";
 import { Link } from "react-router-dom";
 
-import { ComponentPreview, DocContainer, Icon, Attribute, Property, JavascriptDocs } from "#";
+import { ComponentPreview, DocContainer, Attribute, Property, JavascriptDocs } from "#";
 import AlertComponent from "@/Alert";
+import DialogComponent from "@/Dialog";
 
 const { dialog } = window.px;
 
@@ -33,23 +34,9 @@ const Example = () => (
         <h2 id="overview">Example</h2>
         <ComponentPreview language="html" showCasePanel codeFigure>
             <button className="btn btn-executive" type="button" data-dialog-open="demo-dialog">Open dialog</button>
-            <div className="dialog" id="demo-dialog">
-                <section>
-                    <header>
-                        <h4>Delete item 456?</h4>{"\n"}
-                        <a href="#" className="dialog-close">{"\n\t\t\t\t"}
-                            <Icon icon="close" />{"\n\t\t\t"}
-                        </a>{"\n\t\t"}
-                    </header>
-                    <div className="dialog-body">
-                        <p>Are you sure you want to permanently delete the item <i>German Swashbuckle (456)?</i></p>
-                    </div>
-                    <footer>{"\n"}
-                        <button className="btn btn-guiding" type="button" data-dialog-close="demo-dialog">Cancel</button>{"\n"}
-                        <button className="btn btn-destructive" type="button">Delete</button>{"\n"}
-                    </footer>
-                </section>
-            </div>{"\n"}
+            <DialogComponent diaHeader="Delete item 456?" diaId="demo-dialog">
+                <p>Are you sure you want to permanently delete the item <i>German Swashbuckle (456)?</i></p>
+            </DialogComponent>
         </ComponentPreview>
     </>
 );
@@ -61,25 +48,21 @@ const JavascriptMethods = () => (
     </>
 );
 
-class Dialog extends Component {
-    componentDidMount () {
-        dialog.init();
-    }
+const Dialog = () => {
+    useEffect(() => { dialog.init(); });
 
-    render () {
-        return (
-            <DocContainer docToc>
-                <p className="lead">
-                    Dialog is meant to be used to show a snippet of text like a confirmation box before you delete something.
-                    Use <Link to="/docs/components/sheet">sheet</Link> if you wish to receive input from the user or display a large chunk of information.
-                </p>
-                <HowItWorks />
-                <Example />
-                <JavascriptMethods />
-            </DocContainer>
-        );
-    }
-}
+    return (
+        <DocContainer docToc>
+            <p className="lead">
+                Dialog is meant to be used to show a snippet of text like a confirmation box before you delete something.
+                Use <Link to="/docs/components/sheet">sheet</Link> if you wish to receive input from the user or display a large chunk of information.
+            </p>
+            <HowItWorks />
+            <Example />
+            <JavascriptMethods />
+        </DocContainer>
+    );
+};
 
 export default Dialog;
 

--- a/src/App/Documentation/components/Dialog/index.js
+++ b/src/App/Documentation/components/Dialog/index.js
@@ -33,7 +33,7 @@ const Example = () => (
     <>
         <h2 id="overview">Example</h2>
         <ComponentPreview language="html" showCasePanel codeFigure>
-            <button className="btn btn-executive" type="button" data-dialog-open="demo-dialog">Open dialog</button>
+            <button className="btn btn-executive" type="button" data-dialog-open="demo-dialog">{"\n"}Open dialog{"\n"}</button>
             <DialogComponent diaHeader="Delete item 456?" diaId="demo-dialog">
                 <p>Are you sure you want to permanently delete the item <i>German Swashbuckle (456)?</i></p>
             </DialogComponent>

--- a/src/App/Documentation/components/Dialog/index.test.js
+++ b/src/App/Documentation/components/Dialog/index.test.js
@@ -9,12 +9,9 @@ describe("Documentation: Dialog", () => {
     });
 
     it("renders", () => {
-        console.warn = jest.fn();
-
         const wrapper = shallow(<Dialog />);
 
         expect(wrapper).toMatchSnapshot();
-        expect(console.warn).toHaveBeenCalled();
     });
 
     describe("HowItWorks", () => {

--- a/src/App/Documentation/core/Iconography/__snapshots__/index.test.js.snap
+++ b/src/App/Documentation/core/Iconography/__snapshots__/index.test.js.snap
@@ -828,7 +828,7 @@ exports[`Core: Iconography PaymentIcons onClick prevents default 1`] = `
           
 
           <Icon
-            icon="more_vert"
+            type="more_vert"
           />
           
 
@@ -842,7 +842,7 @@ exports[`Core: Iconography PaymentIcons onClick prevents default 1`] = `
               onClick={[Function]}
             >
               <Icon
-                icon="bookmark"
+                type="bookmark"
               />
               Add bookmark
             </a>
@@ -853,7 +853,7 @@ exports[`Core: Iconography PaymentIcons onClick prevents default 1`] = `
               onClick={[Function]}
             >
               <Icon
-                icon="business_center"
+                type="business_center"
               />
               Add client
             </a>
@@ -864,7 +864,7 @@ exports[`Core: Iconography PaymentIcons onClick prevents default 1`] = `
               onClick={[Function]}
             >
               <Icon
-                icon="add_circle"
+                type="add_circle"
               />
               Add document
             </a>
@@ -875,7 +875,7 @@ exports[`Core: Iconography PaymentIcons onClick prevents default 1`] = `
               onClick={[Function]}
             >
               <Icon
-                icon="person_add"
+                type="person_add"
               />
               Add user
             </a>
@@ -1275,7 +1275,7 @@ exports[`Core: Iconography PaymentIcons renders 1`] = `
           
 
           <Icon
-            icon="more_vert"
+            type="more_vert"
           />
           
 
@@ -1289,7 +1289,7 @@ exports[`Core: Iconography PaymentIcons renders 1`] = `
               onClick={[Function]}
             >
               <Icon
-                icon="bookmark"
+                type="bookmark"
               />
               Add bookmark
             </a>
@@ -1300,7 +1300,7 @@ exports[`Core: Iconography PaymentIcons renders 1`] = `
               onClick={[Function]}
             >
               <Icon
-                icon="business_center"
+                type="business_center"
               />
               Add client
             </a>
@@ -1311,7 +1311,7 @@ exports[`Core: Iconography PaymentIcons renders 1`] = `
               onClick={[Function]}
             >
               <Icon
-                icon="add_circle"
+                type="add_circle"
               />
               Add document
             </a>
@@ -1322,7 +1322,7 @@ exports[`Core: Iconography PaymentIcons renders 1`] = `
               onClick={[Function]}
             >
               <Icon
-                icon="person_add"
+                type="person_add"
               />
               Add user
             </a>

--- a/src/App/Documentation/core/Iconography/index.js
+++ b/src/App/Documentation/core/Iconography/index.js
@@ -105,12 +105,12 @@ const PaymentIcons = () => (
                         <span>4925*********004</span>{"\n"}
                     </div>
                     <div className="action-list">{"\n"}
-                        <Icon icon="more_vert" />{"\n"}
+                        <Icon type="more_vert" />{"\n"}
                         <div className="action-menu">{"\n"}
-                            <a href="#" onClick={e => e.preventDefault()}><Icon icon="bookmark"/>Add bookmark</a>{"\n"}
-                            <a href="#" onClick={e => e.preventDefault()}><Icon icon="business_center"/>Add client</a>{"\n"}
-                            <a href="#" onClick={e => e.preventDefault()}><Icon icon="add_circle"/>Add document</a>{"\n"}
-                            <a href="#" onClick={e => e.preventDefault()}><Icon icon="person_add"/>Add user</a>{"\n"}
+                            <a href="#" onClick={e => e.preventDefault()}><Icon type="bookmark"/>Add bookmark</a>{"\n"}
+                            <a href="#" onClick={e => e.preventDefault()}><Icon type="business_center"/>Add client</a>{"\n"}
+                            <a href="#" onClick={e => e.preventDefault()}><Icon type="add_circle"/>Add document</a>{"\n"}
+                            <a href="#" onClick={e => e.preventDefault()}><Icon type="person_add"/>Add user</a>{"\n"}
                         </div>
                     </div>
                 </li>

--- a/src/App/Documentation/core/Lists/__snapshots__/index.test.js.snap
+++ b/src/App/Documentation/core/Lists/__snapshots__/index.test.js.snap
@@ -607,7 +607,7 @@ exports[`Documentation: Lists StripedItemList prevents default on anchors 1`] = 
           
 
           <Icon
-            icon="more_vert"
+            type="more_vert"
           />
           
 
@@ -621,7 +621,7 @@ exports[`Documentation: Lists StripedItemList prevents default on anchors 1`] = 
               onClick={[Function]}
             >
               <Icon
-                icon="bookmark"
+                type="bookmark"
               />
               Add bookmark
             </a>
@@ -632,7 +632,7 @@ exports[`Documentation: Lists StripedItemList prevents default on anchors 1`] = 
               onClick={[Function]}
             >
               <Icon
-                icon="business_center"
+                type="business_center"
               />
               Add client
             </a>
@@ -643,7 +643,7 @@ exports[`Documentation: Lists StripedItemList prevents default on anchors 1`] = 
               onClick={[Function]}
             >
               <Icon
-                icon="add_circle"
+                type="add_circle"
               />
               Add document
             </a>
@@ -654,7 +654,7 @@ exports[`Documentation: Lists StripedItemList prevents default on anchors 1`] = 
               onClick={[Function]}
             >
               <Icon
-                icon="person_add"
+                type="person_add"
               />
               Add user
             </a>
@@ -771,7 +771,7 @@ exports[`Documentation: Lists StripedItemList renders 1`] = `
           
 
           <Icon
-            icon="more_vert"
+            type="more_vert"
           />
           
 
@@ -785,7 +785,7 @@ exports[`Documentation: Lists StripedItemList renders 1`] = `
               onClick={[Function]}
             >
               <Icon
-                icon="bookmark"
+                type="bookmark"
               />
               Add bookmark
             </a>
@@ -796,7 +796,7 @@ exports[`Documentation: Lists StripedItemList renders 1`] = `
               onClick={[Function]}
             >
               <Icon
-                icon="business_center"
+                type="business_center"
               />
               Add client
             </a>
@@ -807,7 +807,7 @@ exports[`Documentation: Lists StripedItemList renders 1`] = `
               onClick={[Function]}
             >
               <Icon
-                icon="add_circle"
+                type="add_circle"
               />
               Add document
             </a>
@@ -818,7 +818,7 @@ exports[`Documentation: Lists StripedItemList renders 1`] = `
               onClick={[Function]}
             >
               <Icon
-                icon="person_add"
+                type="person_add"
               />
               Add user
             </a>

--- a/src/App/Documentation/core/Lists/index.js
+++ b/src/App/Documentation/core/Lists/index.js
@@ -261,12 +261,12 @@ const StripedItemList = () => (
                 <li>
                     <span>4925*********004</span>
                     <div className="action-list">{"\n"}
-                        <Icon icon="more_vert" />{"\n"}
+                        <Icon type="more_vert" />{"\n"}
                         <div className="action-menu">{"\n"}
-                            <a href="#" onClick={e => e.preventDefault()}><Icon icon="bookmark"/>Add bookmark</a>{"\n"}
-                            <a href="#" onClick={e => e.preventDefault()}><Icon icon="business_center"/>Add client</a>{"\n"}
-                            <a href="#" onClick={e => e.preventDefault()}><Icon icon="add_circle"/>Add document</a>{"\n"}
-                            <a href="#" onClick={e => e.preventDefault()}><Icon icon="person_add"/>Add user</a>{"\n"}
+                            <a href="#" onClick={e => e.preventDefault()}><Icon type="bookmark"/>Add bookmark</a>{"\n"}
+                            <a href="#" onClick={e => e.preventDefault()}><Icon type="business_center"/>Add client</a>{"\n"}
+                            <a href="#" onClick={e => e.preventDefault()}><Icon type="add_circle"/>Add document</a>{"\n"}
+                            <a href="#" onClick={e => e.preventDefault()}><Icon type="person_add"/>Add user</a>{"\n"}
                         </div>
                     </div>
                 </li>

--- a/src/App/Documentation/utils/Icon/index.js
+++ b/src/App/Documentation/utils/Icon/index.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-const Icon = ({ icon, classNames }) => <i className={`material-icons${classNames ? ` ${classNames}` : ""}`}>{icon}</i>;
+const Icon = ({ type, classNames }) => <i className={`material-icons${classNames ? ` ${classNames}` : ""}`}>{type}</i>;
 
-Icon.propTypes = { icon: PropTypes.string.isRequired };
+Icon.propTypes = { type: PropTypes.string.isRequired };
 
 export default Icon;

--- a/src/App/Documentation/utils/Icon/index.test.js
+++ b/src/App/Documentation/utils/Icon/index.test.js
@@ -9,7 +9,7 @@ describe("Utilities: Icon", () => {
     });
 
     it("renders correct icon", () => {
-        const wrapper = shallow(<Icon icon="test" />);
+        const wrapper = shallow(<Icon type="test" />);
 
         expect(wrapper).toMatchSnapshot();
         expect(wrapper.contains(<i className="material-icons">test</i>)).toEqual(true);

--- a/src/App/components/ActionList/__snapshots__/index.test.js.snap
+++ b/src/App/components/ActionList/__snapshots__/index.test.js.snap
@@ -119,7 +119,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="bookmark"
+            type="bookmark"
           >
             <i
               className="material-icons"
@@ -136,7 +136,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="business_center"
+            type="business_center"
           >
             <i
               className="material-icons"
@@ -153,7 +153,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="add_circle"
+            type="add_circle"
           >
             <i
               className="material-icons"
@@ -170,7 +170,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="person_add"
+            type="person_add"
           >
             <i
               className="material-icons"
@@ -233,7 +233,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="bookmark"
+            type="bookmark"
           >
             <i
               className="material-icons"
@@ -250,7 +250,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="business_center"
+            type="business_center"
           >
             <i
               className="material-icons"
@@ -267,7 +267,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="add_circle"
+            type="add_circle"
           >
             <i
               className="material-icons"
@@ -284,7 +284,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="person_add"
+            type="person_add"
           >
             <i
               className="material-icons"
@@ -342,7 +342,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="bookmark"
+            type="bookmark"
           >
             <i
               className="material-icons"
@@ -359,7 +359,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="business_center"
+            type="business_center"
           >
             <i
               className="material-icons"
@@ -376,7 +376,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="add_circle"
+            type="add_circle"
           >
             <i
               className="material-icons"
@@ -393,7 +393,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="person_add"
+            type="person_add"
           >
             <i
               className="material-icons"
@@ -457,7 +457,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="bookmark"
+            type="bookmark"
           >
             <i
               className="material-icons"
@@ -474,7 +474,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="business_center"
+            type="business_center"
           >
             <i
               className="material-icons"
@@ -491,7 +491,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="add_circle"
+            type="add_circle"
           >
             <i
               className="material-icons"
@@ -508,7 +508,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="person_add"
+            type="person_add"
           >
             <i
               className="material-icons"
@@ -567,7 +567,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="bookmark"
+            type="bookmark"
           >
             <i
               className="material-icons"
@@ -584,7 +584,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="business_center"
+            type="business_center"
           >
             <i
               className="material-icons"
@@ -601,7 +601,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="add_circle"
+            type="add_circle"
           >
             <i
               className="material-icons"
@@ -618,7 +618,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="person_add"
+            type="person_add"
           >
             <i
               className="material-icons"
@@ -701,7 +701,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="bookmark"
+            type="bookmark"
           >
             <i
               className="material-icons"
@@ -718,7 +718,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="business_center"
+            type="business_center"
           >
             <i
               className="material-icons"
@@ -735,7 +735,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="add_circle"
+            type="add_circle"
           >
             <i
               className="material-icons"
@@ -752,7 +752,7 @@ Array [
           onClick={[Function]}
         >
           <Icon
-            icon="person_add"
+            type="person_add"
           >
             <i
               className="material-icons"
@@ -824,7 +824,7 @@ exports[`Component: ActionList renders with a custom .action-toggle if it is pro
         onClick={[Function]}
       >
         <Icon
-          icon="bookmark"
+          type="bookmark"
         >
           <i
             className="material-icons"
@@ -841,7 +841,7 @@ exports[`Component: ActionList renders with a custom .action-toggle if it is pro
         onClick={[Function]}
       >
         <Icon
-          icon="business_center"
+          type="business_center"
         >
           <i
             className="material-icons"
@@ -858,7 +858,7 @@ exports[`Component: ActionList renders with a custom .action-toggle if it is pro
         onClick={[Function]}
       >
         <Icon
-          icon="add_circle"
+          type="add_circle"
         >
           <i
             className="material-icons"
@@ -875,7 +875,7 @@ exports[`Component: ActionList renders with a custom .action-toggle if it is pro
         onClick={[Function]}
       >
         <Icon
-          icon="person_add"
+          type="person_add"
         >
           <i
             className="material-icons"

--- a/src/App/components/ActionList/index.js
+++ b/src/App/components/ActionList/index.js
@@ -12,7 +12,7 @@ const ActionList = ({ id, classNames, toggleBtn, items }) => (
                     Array.isArray(items) ? items.map(({ name, icon }, i) => (
                         <Fragment key={i}>
                             <a href="#" onClick={e => e.preventDefault()}>
-                                {icon ? <Icon icon={icon}/> : null}{name}
+                                {icon ? <Icon type={icon}/> : null}{name}
                             </a>{"\n"}
                         </Fragment>
                     )) : null

--- a/src/App/components/Alert/__snapshots__/index.test.js.snap
+++ b/src/App/components/Alert/__snapshots__/index.test.js.snap
@@ -160,7 +160,7 @@ exports[`Component: ComplexAlert Proptypes renders with a close button when prop
       
 		
       <Icon
-        icon="close"
+        type="close"
       />
       
 	
@@ -197,7 +197,7 @@ exports[`Component: ComplexAlert Proptypes renders with an icon when prop icon i
      
     <Icon
       classNames="alert-icon"
-      icon="home"
+      type="home"
     />
     
 

--- a/src/App/components/Alert/index.js
+++ b/src/App/components/Alert/index.js
@@ -19,7 +19,7 @@ const ComplexAlert = ({ id, type, icon, close, headerText, children }) => (
         <header className="alert-header">
             {icon
                 ? <>
-                    {"\n"} <Icon classNames="alert-icon" icon={icon}/>
+                    {"\n"} <Icon classNames="alert-icon" type={icon}/>
                 </>
                 : null}
             {headerText
@@ -31,7 +31,7 @@ const ComplexAlert = ({ id, type, icon, close, headerText, children }) => (
                 : null}
             {close
                 ? <a href="#" data-alert-close="" onClick={e => e.preventDefault()}>{"\n\t\t"}
-                    <Icon icon={"close"}/>{"\n\t"}
+                    <Icon type={"close"}/>{"\n\t"}
                 </a>
                 : null}
             {"\n"}

--- a/src/App/components/Dialog/__snapshots__/index.test.js.snap
+++ b/src/App/components/Dialog/__snapshots__/index.test.js.snap
@@ -1,0 +1,200 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component: Dialog -  renders 1`] = `
+<Fragment>
+  <div
+    className="dialog"
+  >
+    <section>
+      <header
+        className="dialog-header"
+      >
+        <h4 />
+        <button
+          className="dialog-close"
+          type="button"
+        >
+          <Icon
+            type="close"
+          />
+        </button>
+      </header>
+      <div
+        className="dialog-body"
+      />
+      <footer
+        className="dialog-footer"
+      >
+        <button
+          className="btn btn-guiding"
+          data-dialog-close={true}
+          type="button"
+        >
+          Cancel
+        </button>
+        
+
+        <button
+          className="btn btn-destructive"
+          type="button"
+        >
+          Delete
+        </button>
+        
+
+      </footer>
+    </section>
+  </div>
+</Fragment>
+`;
+
+exports[`Component: Dialog -  renders with the passed ID 1`] = `
+<Fragment>
+  <div
+    className="dialog"
+    id="my-id"
+  >
+    <section>
+      <header
+        className="dialog-header"
+      >
+        <h4 />
+        <button
+          className="dialog-close"
+          type="button"
+        >
+          <Icon
+            type="close"
+          />
+        </button>
+      </header>
+      <div
+        className="dialog-body"
+      />
+      <footer
+        className="dialog-footer"
+      >
+        <button
+          className="btn btn-guiding"
+          data-dialog-close={true}
+          type="button"
+        >
+          Cancel
+        </button>
+        
+
+        <button
+          className="btn btn-destructive"
+          type="button"
+        >
+          Delete
+        </button>
+        
+
+      </footer>
+    </section>
+  </div>
+</Fragment>
+`;
+
+exports[`Component: Dialog -  renders with the passed children 1`] = `
+<Fragment>
+  <div
+    className="dialog"
+  >
+    <section>
+      <header
+        className="dialog-header"
+      >
+        <h4 />
+        <button
+          className="dialog-close"
+          type="button"
+        >
+          <Icon
+            type="close"
+          />
+        </button>
+      </header>
+      <div
+        className="dialog-body"
+      >
+        <p>
+          My paragraph
+        </p>
+      </div>
+      <footer
+        className="dialog-footer"
+      >
+        <button
+          className="btn btn-guiding"
+          data-dialog-close={true}
+          type="button"
+        >
+          Cancel
+        </button>
+        
+
+        <button
+          className="btn btn-destructive"
+          type="button"
+        >
+          Delete
+        </button>
+        
+
+      </footer>
+    </section>
+  </div>
+</Fragment>
+`;
+
+exports[`Component: Dialog -  renders with the passed header 1`] = `
+<Fragment>
+  <div
+    className="dialog"
+  >
+    <section>
+      <header
+        className="dialog-header"
+      >
+        <h4>
+          My heading
+        </h4>
+        <button
+          className="dialog-close"
+          type="button"
+        >
+          <Icon
+            type="close"
+          />
+        </button>
+      </header>
+      <div
+        className="dialog-body"
+      />
+      <footer
+        className="dialog-footer"
+      >
+        <button
+          className="btn btn-guiding"
+          data-dialog-close={true}
+          type="button"
+        >
+          Cancel
+        </button>
+        
+
+        <button
+          className="btn btn-destructive"
+          type="button"
+        >
+          Delete
+        </button>
+        
+
+      </footer>
+    </section>
+  </div>
+</Fragment>
+`;

--- a/src/App/components/Dialog/__snapshots__/index.test.js.snap
+++ b/src/App/components/Dialog/__snapshots__/index.test.js.snap
@@ -3,7 +3,9 @@
 exports[`Component: Dialog -  renders 1`] = `
 <Fragment>
   <div
+    aria-modal="true"
     className="dialog"
+    role="dialog"
   >
     <section>
       <header
@@ -51,8 +53,10 @@ exports[`Component: Dialog -  renders 1`] = `
 exports[`Component: Dialog -  renders with the passed ID 1`] = `
 <Fragment>
   <div
+    aria-modal="true"
     className="dialog"
     id="my-id"
+    role="dialog"
   >
     <section>
       <header
@@ -100,7 +104,9 @@ exports[`Component: Dialog -  renders with the passed ID 1`] = `
 exports[`Component: Dialog -  renders with the passed children 1`] = `
 <Fragment>
   <div
+    aria-modal="true"
     className="dialog"
+    role="dialog"
   >
     <section>
       <header
@@ -152,7 +158,9 @@ exports[`Component: Dialog -  renders with the passed children 1`] = `
 exports[`Component: Dialog -  renders with the passed header 1`] = `
 <Fragment>
   <div
+    aria-modal="true"
     className="dialog"
+    role="dialog"
   >
     <section>
       <header

--- a/src/App/components/Dialog/__snapshots__/index.test.js.snap
+++ b/src/App/components/Dialog/__snapshots__/index.test.js.snap
@@ -3,6 +3,8 @@
 exports[`Component: Dialog -  renders 1`] = `
 <Fragment>
   <div
+    aria-describedby="aria-describe-dia"
+    aria-labelledby="aria-label-dia"
     aria-modal="true"
     className="dialog"
     role="dialog"
@@ -10,23 +12,33 @@ exports[`Component: Dialog -  renders 1`] = `
     <section>
       <header
         className="dialog-header"
+        id="aria-label-dia"
       >
         <h4 />
+        
+
         <button
           className="dialog-close"
           type="button"
         >
+          
+
           <Icon
             type="close"
           />
+          
+
         </button>
       </header>
       <div
         className="dialog-body"
+        id="aria-describe-dia"
       />
       <footer
         className="dialog-footer"
       >
+        
+
         <button
           className="btn btn-guiding"
           data-dialog-close={true}
@@ -53,6 +65,8 @@ exports[`Component: Dialog -  renders 1`] = `
 exports[`Component: Dialog -  renders with the passed ID 1`] = `
 <Fragment>
   <div
+    aria-describedby="aria-describe-dia"
+    aria-labelledby="aria-label-dia"
     aria-modal="true"
     className="dialog"
     id="my-id"
@@ -61,23 +75,33 @@ exports[`Component: Dialog -  renders with the passed ID 1`] = `
     <section>
       <header
         className="dialog-header"
+        id="aria-label-dia"
       >
         <h4 />
+        
+
         <button
           className="dialog-close"
           type="button"
         >
+          
+
           <Icon
             type="close"
           />
+          
+
         </button>
       </header>
       <div
         className="dialog-body"
+        id="aria-describe-dia"
       />
       <footer
         className="dialog-footer"
       >
+        
+
         <button
           className="btn btn-guiding"
           data-dialog-close={true}
@@ -104,6 +128,8 @@ exports[`Component: Dialog -  renders with the passed ID 1`] = `
 exports[`Component: Dialog -  renders with the passed children 1`] = `
 <Fragment>
   <div
+    aria-describedby="aria-describe-dia"
+    aria-labelledby="aria-label-dia"
     aria-modal="true"
     className="dialog"
     role="dialog"
@@ -111,19 +137,27 @@ exports[`Component: Dialog -  renders with the passed children 1`] = `
     <section>
       <header
         className="dialog-header"
+        id="aria-label-dia"
       >
         <h4 />
+        
+
         <button
           className="dialog-close"
           type="button"
         >
+          
+
           <Icon
             type="close"
           />
+          
+
         </button>
       </header>
       <div
         className="dialog-body"
+        id="aria-describe-dia"
       >
         <p>
           My paragraph
@@ -132,6 +166,8 @@ exports[`Component: Dialog -  renders with the passed children 1`] = `
       <footer
         className="dialog-footer"
       >
+        
+
         <button
           className="btn btn-guiding"
           data-dialog-close={true}
@@ -158,6 +194,8 @@ exports[`Component: Dialog -  renders with the passed children 1`] = `
 exports[`Component: Dialog -  renders with the passed header 1`] = `
 <Fragment>
   <div
+    aria-describedby="aria-describe-dia"
+    aria-labelledby="aria-label-dia"
     aria-modal="true"
     className="dialog"
     role="dialog"
@@ -165,25 +203,35 @@ exports[`Component: Dialog -  renders with the passed header 1`] = `
     <section>
       <header
         className="dialog-header"
+        id="aria-label-dia"
       >
         <h4>
           My heading
         </h4>
+        
+
         <button
           className="dialog-close"
           type="button"
         >
+          
+
           <Icon
             type="close"
           />
+          
+
         </button>
       </header>
       <div
         className="dialog-body"
+        id="aria-describe-dia"
       />
       <footer
         className="dialog-footer"
       >
+        
+
         <button
           className="btn btn-guiding"
           data-dialog-close={true}

--- a/src/App/components/Dialog/index.js
+++ b/src/App/components/Dialog/index.js
@@ -5,7 +5,7 @@ import { Icon } from "#";
 
 const Dialog = ({ diaId, diaHeader, children }) => (
     <>
-        <div className="dialog" id={diaId}>
+        <div className="dialog" id={diaId} role="dialog" aria-modal="true">
             <section>
                 <header className="dialog-header">
                     <h4>{diaHeader}</h4>

--- a/src/App/components/Dialog/index.js
+++ b/src/App/components/Dialog/index.js
@@ -1,0 +1,33 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import { Icon } from "#";
+
+const Dialog = ({ diaId, diaHeader, children }) => (
+    <>
+        <div className="dialog" id={diaId}>
+            <section>
+                <header className="dialog-header">
+                    <h4>{diaHeader}</h4>
+                    <button type="button" className="dialog-close">
+                        <Icon type="close" />
+                    </button>
+                </header>
+                <div className="dialog-body">
+                    {children}
+                </div>
+                <footer className="dialog-footer">
+                    <button className="btn btn-guiding" type="button" data-dialog-close>Cancel</button>{"\n"}
+                    <button className="btn btn-destructive" type="button">Delete</button>{"\n"}
+                </footer>
+            </section>
+        </div>
+    </>
+);
+
+Dialog.propTypes = {
+    diaId: PropTypes.string,
+    diaHeader: PropTypes.string
+};
+
+export default Dialog;

--- a/src/App/components/Dialog/index.js
+++ b/src/App/components/Dialog/index.js
@@ -5,18 +5,18 @@ import { Icon } from "#";
 
 const Dialog = ({ diaId, diaHeader, children }) => (
     <>
-        <div className="dialog" id={diaId} role="dialog" aria-modal="true">
+        <div className="dialog" id={diaId} role="dialog" aria-modal="true" aria-labelledby="aria-label-dia" aria-describedby="aria-describe-dia">
             <section>
-                <header className="dialog-header">
-                    <h4>{diaHeader}</h4>
-                    <button type="button" className="dialog-close">
-                        <Icon type="close" />
+                <header className="dialog-header" id="aria-label-dia">
+                    <h4>{diaHeader}</h4>{"\n"}
+                    <button type="button" className="dialog-close">{"\n"}
+                        <Icon type="close" />{"\n"}
                     </button>
                 </header>
-                <div className="dialog-body">
+                <div className="dialog-body" id="aria-describe-dia">
                     {children}
                 </div>
-                <footer className="dialog-footer">
+                <footer className="dialog-footer">{"\n"}
                     <button className="btn btn-guiding" type="button" data-dialog-close>Cancel</button>{"\n"}
                     <button className="btn btn-destructive" type="button">Delete</button>{"\n"}
                 </footer>

--- a/src/App/components/Dialog/index.test.js
+++ b/src/App/components/Dialog/index.test.js
@@ -1,0 +1,37 @@
+import React from "react";
+import { shallow } from "enzyme";
+
+import Dialog from "./index";
+
+describe("Component: Dialog - ", () => {
+    it("is defined", () => {
+        expect(Dialog).toBeDefined();
+    });
+
+    it("renders", () => {
+        const wrapper = shallow(<Dialog />);
+
+        expect(wrapper).toMatchSnapshot();
+    });
+
+    it("renders with the passed ID", () => {
+        const wrapper = shallow(<Dialog diaId="my-id"/>);
+
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.html()).toContain("my-id");
+    });
+
+    it("renders with the passed header", () => {
+        const wrapper = shallow(<Dialog diaHeader="My heading"/>);
+
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.html()).toContain("My heading");
+    });
+
+    it("renders with the passed children", () => {
+        const wrapper = shallow(<Dialog><p>My paragraph</p></Dialog>);
+
+        expect(wrapper).toMatchSnapshot();
+        expect(wrapper.html()).toContain("<p>My paragraph</p>");
+    });
+});

--- a/src/App/components/Sheet/__snapshots__/index.test.js.snap
+++ b/src/App/components/Sheet/__snapshots__/index.test.js.snap
@@ -15,7 +15,7 @@ exports[`Component: Sheet -  does not render with data-require-action if it is s
       
 			
       <Icon
-        icon="close"
+        type="close"
       />
       
 		
@@ -39,7 +39,7 @@ exports[`Component: Sheet -  renders 1`] = `
       
 			
       <Icon
-        icon="close"
+        type="close"
       />
       
 		
@@ -63,7 +63,7 @@ exports[`Component: Sheet -  renders with a close icon 1`] = `
       
 			
       <Icon
-        icon="close"
+        type="close"
       />
       
 		
@@ -88,7 +88,7 @@ exports[`Component: Sheet -  renders with an ID 1`] = `
       
 			
       <Icon
-        icon="close"
+        type="close"
       />
       
 		
@@ -112,7 +112,7 @@ exports[`Component: Sheet -  renders with children 1`] = `
       
 			
       <Icon
-        icon="close"
+        type="close"
       />
       
 		
@@ -137,7 +137,7 @@ exports[`Component: Sheet -  renders with the data-require-action attribute 1`] 
       
 			
       <Icon
-        icon="close"
+        type="close"
       />
       
 		

--- a/src/App/components/Sheet/index.js
+++ b/src/App/components/Sheet/index.js
@@ -7,7 +7,7 @@ const Sheet = ({ id, requireAction, children }) => (
     <div className="sheet" id={id} data-require-action={requireAction ? true : null}>
         <section>{"\n"}
             <a href="#" className="sheet-close">{"\n\t\t\t"}
-                <Icon icon="close" />{"\n\t\t"}
+                <Icon type="close" />{"\n\t\t"}
             </a>
             {children}
         </section>

--- a/src/less/components/dialog.less
+++ b/src/less/components/dialog.less
@@ -14,6 +14,7 @@
         position: relative;
         max-width: 500px;
 
+        .dialog-header,
         header {
             display: flex;
             padding: 1rem 1.5rem;
@@ -26,15 +27,51 @@
             .h1, .h2, .h3, .h4, .h5, .h6 {
                 margin-top: 0;
                 margin-bottom: 0;
+                flex-grow: 1;
             }
             /* stylelint-enable selector-list-comma-newline-after */
 
             .dialog-close {
-                position: absolute;
-                top: 1rem;
-                right: 1.5rem;
+                display: inline-flex;
+                align-items: center;
+                position: relative;
+                font-weight: normal;
+                font-family: @font-swedbank-headline;
+                text-align: center;
+                text-decoration: none;
+                vertical-align: middle;
+                touch-action: manipulation;
+                cursor: pointer;
+                line-height: 1rem;
+                border: 1px solid transparent;
+                white-space: nowrap;
+                user-select: none;
+                background-color: transparent;
 
-                .close-button();
+                /* padding-top-bottom, padding-left-right, font-size, line-height */
+                .button-size(0.5rem; 0.5rem; 1rem; 1rem; @btn-border-radius-base;);
+
+                margin-right: -0.5rem;
+
+                &:hover,
+                &:focus,
+                &.focus {
+                    color: @dark-brown;
+                    text-decoration: none;
+                }
+
+                &[active],
+                &:active,
+                &.active {
+                    outline: 0;
+                    background-image: none;
+                    box-shadow: none;
+
+                    &:focus,
+                    &.focus {
+                        box-shadow: none;
+                    }
+                }
             }
         }
 
@@ -43,6 +80,7 @@
             padding: 2rem 1.5rem;
         }
 
+        .dialog-footer,
         footer {
             background: @white;
             border-top: @dialog-border;

--- a/src/px-script/main/dialog/index.js
+++ b/src/px-script/main/dialog/index.js
@@ -7,6 +7,8 @@ const SELECTORS = {
     CLOSEICON: ".dialog-close"
 };
 
+const FOCUSELEMENTS = "a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), iframe, object, embed, [tabindex=\"0\"], [contenteditable]";
+
 const _dialogs = _dialogs || [];
 
 class Dialog {
@@ -17,6 +19,12 @@ class Dialog {
         this.isOpen = el.classList.contains("d-flex");
         this.openBtns = this.id ? document.querySelectorAll(`[data-dialog-open=${this.id}]`) : null;
         this.closeBtns = this.id ? document.querySelectorAll(`[data-dialog-close=${this.id}]`) : null;
+
+        this.focusedElemBeforeDialog = null;
+        this.focusableElements = el.querySelectorAll(FOCUSELEMENTS);
+        this.focusableElements = Array.prototype.slice.call(this.focusableElements);
+        this.firstTabStop = this.focusableElements[0];
+        this.lastTabStop = this.focusableElements[this.focusableElements.length - 1];
 
         if (this.closeIcon) {
             this.closeIcon.addEventListener("click", e => {
@@ -33,6 +41,23 @@ class Dialog {
     }
 
     _initializeButtons () {
+        this._el.addEventListener("keydown", e => {
+            if (e.key === "Tab") {
+                // SHIFT + TAB
+                if (e.shiftKey) {
+                    if (document.activeElement === this.firstTabStop) {
+                        e.preventDefault();
+                        this.lastTabStop.focus();
+                    }
+
+                // TAB
+                } else if (document.activeElement === this.lastTabStop) {
+                    e.preventDefault();
+                    this.firstTabStop.focus();
+                }
+            }
+        });
+
         // Init open buttons
         if (this.openBtns) {
             this.openBtns.forEach(btn => {
@@ -55,6 +80,8 @@ class Dialog {
     }
 
     open () {
+        this.focusedElemBeforeDialog = document.activeElement;
+        this._el.focus();
         handleScrollbar();
         this.isOpen = true;
         this._el.classList.add("d-flex");
@@ -66,6 +93,7 @@ class Dialog {
         this.isOpen = false;
         this._el.classList.remove("d-flex");
         document.body.classList.remove("dialog-open");
+        this.focusedElemBeforeDialog.focus();
     }
 }
 

--- a/src/px-script/main/dialog/index.js
+++ b/src/px-script/main/dialog/index.js
@@ -17,12 +17,16 @@ class Dialog {
         this.id = el.id;
         this.closeIcon = el.querySelector(SELECTORS.CLOSEICON);
         this.isOpen = el.classList.contains("d-flex");
-        this.openBtns = this.id ? document.querySelectorAll(`[data-dialog-open=${this.id}]`) : null;
-        this.closeBtns = this.id ? document.querySelectorAll(`[data-dialog-close=${this.id}]`) : null;
 
+        // Find all related buttons
+        this.openBtns = this.id ? [...document.querySelectorAll(`[data-dialog-open=${this.id}]`)] : null;
+        this.closeBtns = this.id ? [...document.querySelectorAll(`[data-dialog-close=${this.id}]`)] : null;
+        this.internalClose = this._el.querySelector("[data-dialog-close]");
+        this.closeBtns.every(closeBtn => closeBtn !== this.internalClose) ? this.closeBtns.push(this.internalClose) : null;
+
+        // Find focusable elements
         this.focusedElemBeforeDialog = null;
-        this.focusableElements = el.querySelectorAll(FOCUSELEMENTS);
-        this.focusableElements = Array.prototype.slice.call(this.focusableElements);
+        this.focusableElements = [...el.querySelectorAll(FOCUSELEMENTS)];
         this.firstTabStop = this.focusableElements[0];
         this.lastTabStop = this.focusableElements[this.focusableElements.length - 1];
 
@@ -37,10 +41,10 @@ class Dialog {
             document.body.classList.add("dialog-open");
         }
 
-        this._initializeButtons();
+        this._initializeListeners();
     }
 
-    _initializeButtons () {
+    _initializeListeners () {
         this._el.addEventListener("keydown", e => {
             if (e.key === "Tab") {
                 // SHIFT + TAB
@@ -81,11 +85,11 @@ class Dialog {
 
     open () {
         this.focusedElemBeforeDialog = document.activeElement;
-        this._el.focus();
         handleScrollbar();
         this.isOpen = true;
         this._el.classList.add("d-flex");
         document.body.classList.add("dialog-open");
+        this.firstTabStop.focus();
     }
 
     close () {

--- a/src/px-script/main/dialog/index.js
+++ b/src/px-script/main/dialog/index.js
@@ -16,13 +16,12 @@ class Dialog {
         this._el = el;
         this.id = el.id;
         this.closeIcon = el.querySelector(SELECTORS.CLOSEICON);
+        this.header = el.querySelector(".dialog-header");
         this.isOpen = el.classList.contains("d-flex");
 
         // Find all related buttons
-        this.openBtns = this.id ? [...document.querySelectorAll(`[data-dialog-open=${this.id}]`)] : null;
-        this.closeBtns = this.id ? [...document.querySelectorAll(`[data-dialog-close=${this.id}]`)] : null;
-        this.internalClose = this._el.querySelector("[data-dialog-close]");
-        this.closeBtns.every(closeBtn => closeBtn !== this.internalClose) ? this.closeBtns.push(this.internalClose) : null;
+        this.openBtns = this.id ? [...document.querySelectorAll(`[data-dialog-open=${this.id}]`)] : [];
+        this.closeBtn = this._el.querySelector("[data-dialog-close]");
 
         // Find focusable elements
         this.focusedElemBeforeDialog = null;
@@ -63,7 +62,7 @@ class Dialog {
         });
 
         // Init open buttons
-        if (this.openBtns) {
+        if (this.openBtns.length) {
             this.openBtns.forEach(btn => {
                 btn.addEventListener("click", e => {
                     e.preventDefault();
@@ -73,12 +72,10 @@ class Dialog {
         }
 
         // Init close buttons
-        if (this.closeBtns) {
-            this.closeBtns.forEach(btn => {
-                btn.addEventListener("click", e => {
-                    e.preventDefault();
-                    this.close();
-                });
+        if (this.closeBtn) {
+            this.closeBtn.addEventListener("click", e => {
+                e.preventDefault();
+                this.close();
             });
         }
     }
@@ -89,7 +86,7 @@ class Dialog {
         this.isOpen = true;
         this._el.classList.add("d-flex");
         document.body.classList.add("dialog-open");
-        this.firstTabStop.focus();
+        this.lastTabStop.focus();
     }
 
     close () {
@@ -97,7 +94,7 @@ class Dialog {
         this.isOpen = false;
         this._el.classList.remove("d-flex");
         document.body.classList.remove("dialog-open");
-        this.focusedElemBeforeDialog.focus();
+        this.focusedElemBeforeDialog ? this.focusedElemBeforeDialog.focus() : null;
     }
 }
 

--- a/src/px-script/main/dialog/index.test.js
+++ b/src/px-script/main/dialog/index.test.js
@@ -47,180 +47,180 @@ describe("px-script: dialog", () => {
         expect(dialog).toBeDefined();
     });
 
-    describe("dialog.init", () => {
-        it("has an init method", () => {
-            expect(dialog.init).toBeDefined();
-            expect(dialog.init).toBeInstanceOf(Function);
-        });
+    // describe("dialog.init", () => {
+    //     it("has an init method", () => {
+    //         expect(dialog.init).toBeDefined();
+    //         expect(dialog.init).toBeInstanceOf(Function);
+    //     });
 
-        it("returns a single object when one ID is passed", () => {
-            ReactDOM.render(<Dialog id="demo-dialog" />, div);
+    //     it("returns a single object when one ID is passed", () => {
+    //         ReactDOM.render(<Dialog id="demo-dialog" />, div);
 
-            const renderedDialog = document.querySelector(".dialog");
+    //         const renderedDialog = document.querySelector(".dialog");
 
-            expect(renderedDialog).toBeTruthy();
+    //         expect(renderedDialog).toBeTruthy();
 
-            const returnVal = dialog.init("demo-dialog");
+    //         const returnVal = dialog.init("demo-dialog");
 
-            expect(Array.isArray(returnVal)).toBeFalsy();
-            expect(typeof returnVal).toEqual("object");
-        });
+    //         expect(Array.isArray(returnVal)).toBeFalsy();
+    //         expect(typeof returnVal).toEqual("object");
+    //     });
 
-        it("returns an array of objects when more than one dialog is initialized", () => {
-            ReactDOM.render(
-                <>
-                    <Dialog />
-                    <Dialog />
-                </>
-                , div);
+    //     it("returns an array of objects when more than one dialog is initialized", () => {
+    //         ReactDOM.render(
+    //             <>
+    //                 <Dialog />
+    //                 <Dialog />
+    //             </>
+    //             , div);
 
-            const renderedDialog = document.querySelectorAll(".dialog");
+    //         const renderedDialog = document.querySelectorAll(".dialog");
 
-            expect(renderedDialog).toBeTruthy();
-            expect(renderedDialog.length).toEqual(2);
+    //         expect(renderedDialog).toBeTruthy();
+    //         expect(renderedDialog.length).toEqual(2);
 
-            const returnVal = dialog.init();
+    //         const returnVal = dialog.init();
 
-            expect(Array.isArray(returnVal)).toBeTruthy();
-            expect(returnVal.length).toEqual(2);
-        });
+    //         expect(Array.isArray(returnVal)).toBeTruthy();
+    //         expect(returnVal.length).toEqual(2);
+    //     });
 
-        it("init returns null if no dialog is found and prints a warning message", () => {
-            console.warn = jest.fn();
+    //     it("init returns null if no dialog is found and prints a warning message", () => {
+    //         console.warn = jest.fn();
 
-            expect(dialog.init()).toBeNull();
-            expect(console.warn).toHaveBeenCalled();
-        });
+    //         expect(dialog.init()).toBeNull();
+    //         expect(console.warn).toHaveBeenCalled();
+    //     });
 
-        it("returns null if an invalid ID is passed and prints a warning message", () => {
-            console.warn = jest.fn();
+    //     it("returns null if an invalid ID is passed and prints a warning message", () => {
+    //         console.warn = jest.fn();
 
-            expect(dialog.init("test")).toBeNull();
-            expect(console.warn).toHaveBeenCalled();
-        });
-    });
+    //         expect(dialog.init("test")).toBeNull();
+    //         expect(console.warn).toHaveBeenCalled();
+    //     });
+    // });
 
-    it("button with attribute 'data-dialog-open' pointing to the correct id opens corresponding dialog", () => {
-        ReactDOM.render(<Dialog id="demo-dialog" />, div);
+    // it("button with attribute 'data-dialog-open' pointing to the correct id opens corresponding dialog", () => {
+    //     ReactDOM.render(<Dialog id="demo-dialog" />, div);
 
-        const renderedDialog = document.querySelector(".dialog");
-        const openBtn = document.querySelector("[data-dialog-open]");
+    //     const renderedDialog = document.querySelector(".dialog");
+    //     const openBtn = document.querySelector("[data-dialog-open]");
 
-        expect(renderedDialog.classList).not.toContain("d-flex");
+    //     expect(renderedDialog.classList).not.toContain("d-flex");
 
-        dialog.init();
-        expect(document.body.classList).not.toContain("dialog-open");
+    //     dialog.init();
+    //     expect(document.body.classList).not.toContain("dialog-open");
 
-        openBtn.click();
-        expect(renderedDialog.classList).toContain("d-flex");
-        expect(document.body.classList).toContain("dialog-open");
-    });
+    //     openBtn.click();
+    //     expect(renderedDialog.classList).toContain("d-flex");
+    //     expect(document.body.classList).toContain("dialog-open");
+    // });
 
-    it("button with attribute 'data-dialog-close' pointing to the correct id closes corresponding dialog", () => {
-        ReactDOM.render(<Dialog id="demo-dialog" open />, div);
+    // it("button with attribute 'data-dialog-close' pointing to the correct id closes corresponding dialog", () => {
+    //     ReactDOM.render(<Dialog id="demo-dialog" open />, div);
 
-        const renderedDialog = document.querySelector(".dialog");
-        const closeBtn = document.querySelector("[data-dialog-close]");
+    //     const renderedDialog = document.querySelector(".dialog");
+    //     const closeBtn = document.querySelector("[data-dialog-close]");
 
-        expect(renderedDialog.classList).toContain("d-flex");
+    //     expect(renderedDialog.classList).toContain("d-flex");
 
-        dialog.init();
-        expect(document.body.classList).toContain("dialog-open");
+    //     dialog.init();
+    //     expect(document.body.classList).toContain("dialog-open");
 
-        closeBtn.click();
-        expect(renderedDialog.classList).not.toContain("d-flex");
-        expect(document.body.classList).not.toContain("dialog-open");
-    });
+    //     closeBtn.click();
+    //     expect(renderedDialog.classList).not.toContain("d-flex");
+    //     expect(document.body.classList).not.toContain("dialog-open");
+    // });
 
-    it("closes dialog when clicking the close icon", () => {
-        ReactDOM.render(<Dialog id="demo-dialog" open />, div);
+    // it("closes dialog when clicking the close icon", () => {
+    //     ReactDOM.render(<Dialog id="demo-dialog" open />, div);
 
-        const renderedDialog = document.querySelector(".dialog");
-        const closeIcon = renderedDialog.querySelector(".dialog-close");
+    //     const renderedDialog = document.querySelector(".dialog");
+    //     const closeIcon = renderedDialog.querySelector(".dialog-close");
 
-        expect(renderedDialog.classList).toContain("d-flex");
+    //     expect(renderedDialog.classList).toContain("d-flex");
 
-        dialog.init();
-        expect(document.body.classList).toContain("dialog-open");
+    //     dialog.init();
+    //     expect(document.body.classList).toContain("dialog-open");
 
-        closeIcon.click();
+    //     closeIcon.click();
 
-        expect(renderedDialog.classList).not.toContain("d-flex");
-        expect(document.body.classList).not.toContain("dialog-open");
-    });
+    //     expect(renderedDialog.classList).not.toContain("d-flex");
+    //     expect(document.body.classList).not.toContain("dialog-open");
+    // });
 
-    describe("dialog.open", () => {
-        it("opens dialog when calling dialog.open", () => {
-            ReactDOM.render(<Dialog id="demo-dialog" />, div);
+    // describe("dialog.open", () => {
+    //     it("opens dialog when calling dialog.open", () => {
+    //         ReactDOM.render(<Dialog id="demo-dialog" />, div);
 
-            const renderedDialog = document.querySelector(".dialog");
+    //         const renderedDialog = document.querySelector(".dialog");
 
-            expect(renderedDialog.classList).not.toContain("d-flex");
-            expect(document.body.classList).not.toContain("dialog-open");
+    //         expect(renderedDialog.classList).not.toContain("d-flex");
+    //         expect(document.body.classList).not.toContain("dialog-open");
 
-            dialog.init();
-            expect(document.body.classList).not.toContain("dialog-open");
+    //         dialog.init();
+    //         expect(document.body.classList).not.toContain("dialog-open");
 
-            dialog.open("demo-dialog");
+    //         dialog.open("demo-dialog");
 
-            expect(renderedDialog.classList).toContain("d-flex");
-            expect(document.body.classList).toContain("dialog-open");
-        });
+    //         expect(renderedDialog.classList).toContain("d-flex");
+    //         expect(document.body.classList).toContain("dialog-open");
+    //     });
 
-        it("does not open dialog when calling dialog.open with wrong id and prints warn to console", () => {
-            console.warn = jest.fn();
-            ReactDOM.render(<Dialog id="demo-dialog" />, div);
+    //     it("does not open dialog when calling dialog.open with wrong id and prints warn to console", () => {
+    //         console.warn = jest.fn();
+    //         ReactDOM.render(<Dialog id="demo-dialog" />, div);
 
-            const renderedDialog = document.querySelector(".dialog");
+    //         const renderedDialog = document.querySelector(".dialog");
 
-            expect(renderedDialog.classList).not.toContain("d-flex");
+    //         expect(renderedDialog.classList).not.toContain("d-flex");
 
-            dialog.init();
-            expect(document.body.classList).not.toContain("dialog-open");
+    //         dialog.init();
+    //         expect(document.body.classList).not.toContain("dialog-open");
 
-            dialog.open("qwerty");
+    //         dialog.open("qwerty");
 
-            expect(console.warn).toHaveBeenCalledWith("dialog.open: No dialog with id \"qwerty\" found.");
+    //         expect(console.warn).toHaveBeenCalledWith("dialog.open: No dialog with id \"qwerty\" found.");
 
-            expect(renderedDialog.classList).not.toContain("d-flex");
-            expect(document.body.classList).not.toContain("dialog-open");
-        });
-    });
+    //         expect(renderedDialog.classList).not.toContain("d-flex");
+    //         expect(document.body.classList).not.toContain("dialog-open");
+    //     });
+    // });
 
-    describe("dialog.close", () => {
-        it("closes dialog when calling dialog.close", () => {
-            ReactDOM.render(<Dialog id="demo-dialog" open />, div);
+    // describe("dialog.close", () => {
+    //     it("closes dialog when calling dialog.close", () => {
+    //         ReactDOM.render(<Dialog id="demo-dialog" open />, div);
 
-            const renderedDialog = document.querySelector(".dialog");
+    //         const renderedDialog = document.querySelector(".dialog");
 
-            expect(renderedDialog.classList).toContain("d-flex");
+    //         expect(renderedDialog.classList).toContain("d-flex");
 
-            dialog.init();
-            expect(document.body.classList).toContain("dialog-open");
+    //         dialog.init();
+    //         expect(document.body.classList).toContain("dialog-open");
 
-            dialog.close("demo-dialog");
+    //         dialog.close("demo-dialog");
 
-            expect(renderedDialog.classList).not.toContain("d-flex");
-            expect(document.body.classList).not.toContain("dialog-open");
-        });
+    //         expect(renderedDialog.classList).not.toContain("d-flex");
+    //         expect(document.body.classList).not.toContain("dialog-open");
+    //     });
 
-        it("does not close dialog when calling dialog.close with wrong id and prints warn to console", () => {
-            console.warn = jest.fn();
-            ReactDOM.render(<Dialog id="demo-dialog" open />, div);
+    //     it("does not close dialog when calling dialog.close with wrong id and prints warn to console", () => {
+    //         console.warn = jest.fn();
+    //         ReactDOM.render(<Dialog id="demo-dialog" open />, div);
 
-            const renderedDialog = document.querySelector(".dialog");
+    //         const renderedDialog = document.querySelector(".dialog");
 
-            expect(renderedDialog.classList).toContain("d-flex");
+    //         expect(renderedDialog.classList).toContain("d-flex");
 
-            dialog.init();
-            expect(document.body.classList).toContain("dialog-open");
+    //         dialog.init();
+    //         expect(document.body.classList).toContain("dialog-open");
 
-            dialog.close("qwerty");
+    //         dialog.close("qwerty");
 
-            expect(console.warn).toHaveBeenCalledWith("dialog.close: No dialog with id \"qwerty\" found.");
+    //         expect(console.warn).toHaveBeenCalledWith("dialog.close: No dialog with id \"qwerty\" found.");
 
-            expect(renderedDialog.classList).toContain("d-flex");
-            expect(document.body.classList).toContain("dialog-open");
-        });
-    });
+    //         expect(renderedDialog.classList).toContain("d-flex");
+    //         expect(document.body.classList).toContain("dialog-open");
+    //     });
+    // });
 });

--- a/src/px-script/main/dialog/index.test.js
+++ b/src/px-script/main/dialog/index.test.js
@@ -13,24 +13,23 @@ describe("px-script: dialog", () => {
 
         return (
             <>
-                <div className={`dialog ${open ? " d-flex" : null}`} id={id}>
+                <button className="btn btn-executive" type="button" data-dialog-open={btnId}>
+                    Open dialog
+                </button>
+                <div className={`dialog ${open ? " d-flex" : null}`} id={id} role="dialog" aria-modal="true">
                     <section>
-                        <header>
-                            <h5>Delete item 456?</h5>
-                            <a href="#" className="dialog-close">
-                                <i className="material-icons">close</i>
-                            </a>
+                        <header className="dialog-header">
+                            <h4>Delete item 456?</h4><button type="button" className="dialog-close"><i className="material-icons">close</i></button>
                         </header>
                         <div className="dialog-body">
                             <p>Are you sure you want to permanently delete the item <i>German Swashbuckle (456)?</i></p>
                         </div>
-                        <footer>
-                            <button className="btn btn-secondary" type="button" data-dialog-close={id}>Cancel</button>
-                            <button className="btn btn-danger" type="button">Delete</button>
+                        <footer className="dialog-footer">
+                            <button className="btn btn-guiding" type="button" data-dialog-close>Cancel</button>
+                            <button className="btn btn-destructive" type="button">Delete</button>
                         </footer>
                     </section>
                 </div>
-                <button className="btn btn-primary" type="button" data-dialog-open={btnId}>Open dialog</button>
             </>
         );
     };
@@ -47,180 +46,224 @@ describe("px-script: dialog", () => {
         expect(dialog).toBeDefined();
     });
 
-    // describe("dialog.init", () => {
-    //     it("has an init method", () => {
-    //         expect(dialog.init).toBeDefined();
-    //         expect(dialog.init).toBeInstanceOf(Function);
-    //     });
+    describe("dialog.init", () => {
+        it("has an init method", () => {
+            expect(dialog.init).toBeDefined();
+            expect(dialog.init).toBeInstanceOf(Function);
+        });
 
-    //     it("returns a single object when one ID is passed", () => {
-    //         ReactDOM.render(<Dialog id="demo-dialog" />, div);
+        it("returns a single object when one ID is passed", () => {
+            ReactDOM.render(<Dialog id="demo-dialog" />, div);
 
-    //         const renderedDialog = document.querySelector(".dialog");
+            const renderedDialog = document.querySelector(".dialog");
 
-    //         expect(renderedDialog).toBeTruthy();
+            expect(renderedDialog).toBeTruthy();
 
-    //         const returnVal = dialog.init("demo-dialog");
+            const returnVal = dialog.init("demo-dialog");
 
-    //         expect(Array.isArray(returnVal)).toBeFalsy();
-    //         expect(typeof returnVal).toEqual("object");
-    //     });
+            expect(Array.isArray(returnVal)).toBeFalsy();
+            expect(typeof returnVal).toEqual("object");
+        });
 
-    //     it("returns an array of objects when more than one dialog is initialized", () => {
-    //         ReactDOM.render(
-    //             <>
-    //                 <Dialog />
-    //                 <Dialog />
-    //             </>
-    //             , div);
+        it("returns an array of objects when more than one dialog is initialized", () => {
+            ReactDOM.render(
+                <>
+                    <Dialog />
+                    <Dialog />
+                </>
+                , div);
 
-    //         const renderedDialog = document.querySelectorAll(".dialog");
+            const renderedDialog = document.querySelectorAll(".dialog");
 
-    //         expect(renderedDialog).toBeTruthy();
-    //         expect(renderedDialog.length).toEqual(2);
+            expect(renderedDialog).toBeTruthy();
+            expect(renderedDialog.length).toEqual(2);
 
-    //         const returnVal = dialog.init();
+            const returnVal = dialog.init();
 
-    //         expect(Array.isArray(returnVal)).toBeTruthy();
-    //         expect(returnVal.length).toEqual(2);
-    //     });
+            expect(Array.isArray(returnVal)).toBeTruthy();
+            expect(returnVal.length).toEqual(2);
+        });
 
-    //     it("init returns null if no dialog is found and prints a warning message", () => {
-    //         console.warn = jest.fn();
+        it("init returns null if no dialog is found and prints a warning message", () => {
+            console.warn = jest.fn();
 
-    //         expect(dialog.init()).toBeNull();
-    //         expect(console.warn).toHaveBeenCalled();
-    //     });
+            expect(dialog.init()).toBeNull();
+            expect(console.warn).toHaveBeenCalled();
+        });
 
-    //     it("returns null if an invalid ID is passed and prints a warning message", () => {
-    //         console.warn = jest.fn();
+        it("returns null if an invalid ID is passed and prints a warning message", () => {
+            console.warn = jest.fn();
 
-    //         expect(dialog.init("test")).toBeNull();
-    //         expect(console.warn).toHaveBeenCalled();
-    //     });
-    // });
+            expect(dialog.init("test")).toBeNull();
+            expect(console.warn).toHaveBeenCalled();
+        });
+    });
 
-    // it("button with attribute 'data-dialog-open' pointing to the correct id opens corresponding dialog", () => {
-    //     ReactDOM.render(<Dialog id="demo-dialog" />, div);
+    it("button with attribute 'data-dialog-open' pointing to the correct id opens corresponding dialog", () => {
+        ReactDOM.render(<Dialog id="demo-dialog" />, div);
 
-    //     const renderedDialog = document.querySelector(".dialog");
-    //     const openBtn = document.querySelector("[data-dialog-open]");
+        const renderedDialog = document.querySelector(".dialog");
+        const openBtn = document.querySelector("[data-dialog-open]");
 
-    //     expect(renderedDialog.classList).not.toContain("d-flex");
+        expect(renderedDialog.classList).not.toContain("d-flex");
 
-    //     dialog.init();
-    //     expect(document.body.classList).not.toContain("dialog-open");
+        dialog.init();
+        expect(document.body.classList).not.toContain("dialog-open");
 
-    //     openBtn.click();
-    //     expect(renderedDialog.classList).toContain("d-flex");
-    //     expect(document.body.classList).toContain("dialog-open");
-    // });
+        openBtn.click();
+        expect(renderedDialog.classList).toContain("d-flex");
+        expect(document.body.classList).toContain("dialog-open");
+    });
 
-    // it("button with attribute 'data-dialog-close' pointing to the correct id closes corresponding dialog", () => {
-    //     ReactDOM.render(<Dialog id="demo-dialog" open />, div);
+    it("button with attribute 'data-dialog-close' pointing to the correct id closes corresponding dialog", () => {
+        ReactDOM.render(<Dialog id="demo-dialog" open />, div);
 
-    //     const renderedDialog = document.querySelector(".dialog");
-    //     const closeBtn = document.querySelector("[data-dialog-close]");
+        const renderedDialog = document.querySelector(".dialog");
+        const closeBtn = document.querySelector("[data-dialog-close]");
 
-    //     expect(renderedDialog.classList).toContain("d-flex");
+        expect(renderedDialog.classList).toContain("d-flex");
 
-    //     dialog.init();
-    //     expect(document.body.classList).toContain("dialog-open");
+        dialog.init();
+        expect(document.body.classList).toContain("dialog-open");
 
-    //     closeBtn.click();
-    //     expect(renderedDialog.classList).not.toContain("d-flex");
-    //     expect(document.body.classList).not.toContain("dialog-open");
-    // });
+        closeBtn.click();
+        expect(renderedDialog.classList).not.toContain("d-flex");
+        expect(document.body.classList).not.toContain("dialog-open");
+    });
 
-    // it("closes dialog when clicking the close icon", () => {
-    //     ReactDOM.render(<Dialog id="demo-dialog" open />, div);
+    it("closes dialog when clicking the close icon", () => {
+        ReactDOM.render(<Dialog id="demo-dialog" open />, div);
 
-    //     const renderedDialog = document.querySelector(".dialog");
-    //     const closeIcon = renderedDialog.querySelector(".dialog-close");
+        const renderedDialog = document.querySelector(".dialog");
+        const closeIcon = renderedDialog.querySelector(".dialog-close");
 
-    //     expect(renderedDialog.classList).toContain("d-flex");
+        expect(renderedDialog.classList).toContain("d-flex");
 
-    //     dialog.init();
-    //     expect(document.body.classList).toContain("dialog-open");
+        dialog.init();
+        expect(document.body.classList).toContain("dialog-open");
 
-    //     closeIcon.click();
+        closeIcon.click();
 
-    //     expect(renderedDialog.classList).not.toContain("d-flex");
-    //     expect(document.body.classList).not.toContain("dialog-open");
-    // });
+        expect(renderedDialog.classList).not.toContain("d-flex");
+        expect(document.body.classList).not.toContain("dialog-open");
+    });
 
-    // describe("dialog.open", () => {
-    //     it("opens dialog when calling dialog.open", () => {
-    //         ReactDOM.render(<Dialog id="demo-dialog" />, div);
+    it("sets focus on the last focusable element when dialog is opened", () => {
+        ReactDOM.render(<Dialog id="dia-id"/>, div);
 
-    //         const renderedDialog = document.querySelector(".dialog");
+        const delBtn = document.querySelector(".btn-destructive");
 
-    //         expect(renderedDialog.classList).not.toContain("d-flex");
-    //         expect(document.body.classList).not.toContain("dialog-open");
+        dialog.init();
+        dialog.open("dia-id");
 
-    //         dialog.init();
-    //         expect(document.body.classList).not.toContain("dialog-open");
+        expect(document.activeElement).toEqual(delBtn);
+    });
 
-    //         dialog.open("demo-dialog");
+    // It is not possible to trigger a focus change with keyboardevents, this is due to some security issues with JS [AW].
+    it("changes focus from the last focusable element to the first focusable element when focus change is induced", () => {
+        ReactDOM.render(<Dialog id="dia-id"/>, div);
 
-    //         expect(renderedDialog.classList).toContain("d-flex");
-    //         expect(document.body.classList).toContain("dialog-open");
-    //     });
+        const dialogElem = document.querySelector(".dialog");
+        const ev = new KeyboardEvent("keydown", { key: "Tab" });
 
-    //     it("does not open dialog when calling dialog.open with wrong id and prints warn to console", () => {
-    //         console.warn = jest.fn();
-    //         ReactDOM.render(<Dialog id="demo-dialog" />, div);
+        const diaObj = dialog.init()[0];
 
-    //         const renderedDialog = document.querySelector(".dialog");
+        diaObj.open();
+        dialogElem.dispatchEvent(ev);
 
-    //         expect(renderedDialog.classList).not.toContain("d-flex");
+        expect(document.activeElement).toEqual(diaObj.firstTabStop);
+    });
 
-    //         dialog.init();
-    //         expect(document.body.classList).not.toContain("dialog-open");
+    it("changes focus from the first focusable element to the last focusable element when focus change is induced", () => {
+        ReactDOM.render(<Dialog id="dia-id"/>, div);
 
-    //         dialog.open("qwerty");
+        const dialogElem = document.querySelector(".dialog");
+        const sEv = new KeyboardEvent("keydown", {
+            shiftKey: true,
+            key: "Tab"
+        });
+        const ev = new KeyboardEvent("keydown", { key: "Tab" });
+        const diaObj = dialog.init()[0];
 
-    //         expect(console.warn).toHaveBeenCalledWith("dialog.open: No dialog with id \"qwerty\" found.");
+        diaObj.open();
+        dialogElem.dispatchEvent(ev);
+        dialogElem.dispatchEvent(sEv);
 
-    //         expect(renderedDialog.classList).not.toContain("d-flex");
-    //         expect(document.body.classList).not.toContain("dialog-open");
-    //     });
-    // });
+        expect(document.activeElement).toEqual(diaObj.lastTabStop);
+    });
 
-    // describe("dialog.close", () => {
-    //     it("closes dialog when calling dialog.close", () => {
-    //         ReactDOM.render(<Dialog id="demo-dialog" open />, div);
+    describe("dialog.open", () => {
+        it("opens dialog when calling dialog.open", () => {
+            ReactDOM.render(<Dialog id="demo-dialog" />, div);
 
-    //         const renderedDialog = document.querySelector(".dialog");
+            const renderedDialog = document.querySelector(".dialog");
 
-    //         expect(renderedDialog.classList).toContain("d-flex");
+            expect(renderedDialog.classList).not.toContain("d-flex");
+            expect(document.body.classList).not.toContain("dialog-open");
 
-    //         dialog.init();
-    //         expect(document.body.classList).toContain("dialog-open");
+            dialog.init();
+            expect(document.body.classList).not.toContain("dialog-open");
 
-    //         dialog.close("demo-dialog");
+            dialog.open("demo-dialog");
 
-    //         expect(renderedDialog.classList).not.toContain("d-flex");
-    //         expect(document.body.classList).not.toContain("dialog-open");
-    //     });
+            expect(renderedDialog.classList).toContain("d-flex");
+            expect(document.body.classList).toContain("dialog-open");
+        });
 
-    //     it("does not close dialog when calling dialog.close with wrong id and prints warn to console", () => {
-    //         console.warn = jest.fn();
-    //         ReactDOM.render(<Dialog id="demo-dialog" open />, div);
+        it("does not open dialog when calling dialog.open with wrong id and prints warn to console", () => {
+            console.warn = jest.fn();
+            ReactDOM.render(<Dialog id="demo-dialog" />, div);
 
-    //         const renderedDialog = document.querySelector(".dialog");
+            const renderedDialog = document.querySelector(".dialog");
 
-    //         expect(renderedDialog.classList).toContain("d-flex");
+            expect(renderedDialog.classList).not.toContain("d-flex");
 
-    //         dialog.init();
-    //         expect(document.body.classList).toContain("dialog-open");
+            dialog.init();
+            expect(document.body.classList).not.toContain("dialog-open");
 
-    //         dialog.close("qwerty");
+            dialog.open("qwerty");
 
-    //         expect(console.warn).toHaveBeenCalledWith("dialog.close: No dialog with id \"qwerty\" found.");
+            expect(console.warn).toHaveBeenCalledWith("dialog.open: No dialog with id \"qwerty\" found.");
 
-    //         expect(renderedDialog.classList).toContain("d-flex");
-    //         expect(document.body.classList).toContain("dialog-open");
-    //     });
-    // });
+            expect(renderedDialog.classList).not.toContain("d-flex");
+            expect(document.body.classList).not.toContain("dialog-open");
+        });
+    });
+
+    describe("dialog.close", () => {
+        it("closes dialog when calling dialog.close", () => {
+            ReactDOM.render(<Dialog id="demo-dialog" open />, div);
+
+            const renderedDialog = document.querySelector(".dialog");
+
+            expect(renderedDialog.classList).toContain("d-flex");
+
+            dialog.init();
+            expect(document.body.classList).toContain("dialog-open");
+
+            dialog.close("demo-dialog");
+
+            expect(renderedDialog.classList).not.toContain("d-flex");
+            expect(document.body.classList).not.toContain("dialog-open");
+        });
+
+        it("does not close dialog when calling dialog.close with wrong id and prints warn to console", () => {
+            console.warn = jest.fn();
+            ReactDOM.render(<Dialog id="demo-dialog" open />, div);
+
+            const renderedDialog = document.querySelector(".dialog");
+
+            expect(renderedDialog.classList).toContain("d-flex");
+
+            dialog.init();
+            expect(document.body.classList).toContain("dialog-open");
+
+            dialog.close("qwerty");
+
+            expect(console.warn).toHaveBeenCalledWith("dialog.close: No dialog with id \"qwerty\" found.");
+
+            expect(renderedDialog.classList).toContain("d-flex");
+            expect(document.body.classList).toContain("dialog-open");
+        });
+    });
 });


### PR DESCRIPTION
### Added

- Added .dialog-header and .dialog-footer to the dialog component.
- Added tab lock to dialog making it so you can't tab out of the dialog until an option is clicked.
- Added aria labels to dialog documentation to show an example of how to use dialog accessibly.

### Changed

- Made it so you don't have to include the ID on the close buttons inside Dialog.
- Changed the close button in dialog to be a button instead of an icon.

