### PR TITLE
Update import aliases and files using them

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -12,20 +12,20 @@
                     "rootPathSuffix": "./"
                 },
                 {
-                    "rootPathPrefix": "$",
+                    "rootPathPrefix": "@src",
                     "rootPathSuffix": "./src"
                 },
                 {
-                    "rootPathPrefix": "@",
+                    "rootPathPrefix": "@components",
                     "rootPathSuffix": "./src/App/components"
                 },
                 {
-                    "rootPathPrefix": "#",
+                    "rootPathPrefix": "@docutils",
                     "rootPathSuffix": "./src/App/Documentation/utils"
 
                 },
                 {
-                    "rootPathPrefix": "+",
+                    "rootPathPrefix": "@constants",
                     "rootPathSuffix": "./src/constants"
                 }
             ]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,8 +52,8 @@ Create a new file under `./src/App/Documentation/Components/[MyExampleDocumentat
 import React from "react";
 
 //Read more about the import shortcuts in the readme (#, @, $ etc.)
-import { ComponentPreview, DocContainer } from "#";
-import MyExampleComponent from "@/MyExampleComponent";
+import { ComponentPreview, DocContainer } from "@docutils";
+import MyExampleComponent from "@components/MyExampleComponent";
 
 const MyExampleDocumentationComponent = () => (
     <DocContainer docToc>

--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ When importing different components in the files you create, you can use shortcu
 
 - `~` - root of the project (example `import package from "~/package";`).
 - `$` - `~/src`-folder (example `import px from "$/px-script";`).
-- `@` - `~/src/App/components`-folder (example `import Alert from "@/Alert";`).
-- `#` - `~/src/App/Documentation/utils`-folder (example `import { DocToc } from "#";`).
+- `@` - `~/src/App/components`-folder (example `import Alert from "@components/Alert";`).
+- `#` - `~/src/App/Documentation/utils`-folder (example `import { DocToc } from "@docutils";`).
 
 The shortcuts are specified in the `~/.babelrc`-file. Specifying the prefix-shortcuts in the `~/jsconfig.json`-file enables path intellisense for the shortcuts (at least in VSCode).
 

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -3,9 +3,9 @@
         "baseUrl": "./",
         "paths": {
             "~/*": ["./*"],
-            "$/*": ["./src/*"],
-            "@/*": ["./src/App/components/*"],
-            "#/*": ["./src/App/Documentation/utils/*"]
+            "@src/*": ["./src/*"],
+            "@components/*": ["./src/App/components/*"],
+            "@docutils/*": ["./src/App/Documentation/utils/*"]
         }
     }
 }

--- a/src/App/Documentation/components/ActionLink/index.js
+++ b/src/App/Documentation/components/ActionLink/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ComponentPreview, DocContainer } from "#";
+import { ComponentPreview, DocContainer } from "@docutils";
 
 const Overview = () => (
     <>

--- a/src/App/Documentation/components/ActionList/index.js
+++ b/src/App/Documentation/components/ActionList/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 
-import ActionListComponent from "@/ActionList";
-import { ComponentPreview, DocContainer, JavascriptDocs } from "#";
+import ActionListComponent from "@components/ActionList";
+import { ComponentPreview, DocContainer, JavascriptDocs } from "@docutils";
 
 const { actionList } = window.px;
 

--- a/src/App/Documentation/components/Alerts/index.js
+++ b/src/App/Documentation/components/Alerts/index.js
@@ -2,8 +2,8 @@ import React, { Component } from "react";
 import { Link } from "react-router-dom";
 import PrismCode from "react-prism";
 
-import { ComponentPreview, Attribute, Property, DocContainer, JavascriptDocs } from "#";
-import AlertComponent, { ComplexAlert } from "@/Alert";
+import { ComponentPreview, Attribute, Property, DocContainer, JavascriptDocs } from "@docutils";
+import AlertComponent, { ComplexAlert } from "@components/Alert";
 
 const { alert } = window.px;
 

--- a/src/App/Documentation/components/Badge/index.js
+++ b/src/App/Documentation/components/Badge/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ComponentPreview, Property, DocContainer } from "#";
+import { ComponentPreview, Property, DocContainer } from "@docutils";
 
 const Overview = () => (
     <>

--- a/src/App/Documentation/components/Breadcrumb/index.js
+++ b/src/App/Documentation/components/Breadcrumb/index.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PrismCode from "react-prism";
 
-import { ComponentPreview, Property, DocContainer } from "#";
-import BreadcrumbComponent from "@/Breadcrumb";
+import { ComponentPreview, Property, DocContainer } from "@docutils";
+import BreadcrumbComponent from "@components/Breadcrumb";
 
 const BasicBreadCrumb = () => {
     const items = [

--- a/src/App/Documentation/components/Buttons/index.js
+++ b/src/App/Documentation/components/Buttons/index.js
@@ -2,9 +2,9 @@ import React from "react";
 import { Link } from "react-router-dom";
 import PrismCode from "react-prism";
 
-import { ComponentPreview, Attribute, Property, DocContainer } from "#";
-import ButtonComponent from "@/Button";
-import Alert from "@/Alert";
+import { ComponentPreview, Attribute, Property, DocContainer } from "@docutils";
+import ButtonComponent from "@components/Button";
+import Alert from "@components/Alert";
 
 const Examples = () => (
     <>

--- a/src/App/Documentation/components/Card/index.js
+++ b/src/App/Documentation/components/Card/index.js
@@ -1,9 +1,9 @@
 import React, { Component } from "react";
 import { Link } from "react-router-dom";
 
-import { ComponentPreview, Property, DocContainer } from "#";
-import CardComponent from "@/Card";
-import MediaObject from "@/MediaObject";
+import { ComponentPreview, Property, DocContainer } from "@docutils";
+import CardComponent from "@components/Card";
+import MediaObject from "@components/MediaObject";
 
 const textArr = ["This is a lot of text", "With some more text", "And then even some more", "Is it really possible to have this much text in one card?", "Yes!"];
 

--- a/src/App/Documentation/components/Datepickers/index.js
+++ b/src/App/Documentation/components/Datepickers/index.js
@@ -1,9 +1,9 @@
 import React, { Component } from "react";
 import { NavHashLink as NavLink } from "react-router-hash-link";
 
-import { ComponentPreview, Attribute, Property, DocContainer, JavascriptDocs } from "#";
-import { Datepicker as DatepickerComponent } from "@/FormComponents";
-import Alert from "@/Alert";
+import { ComponentPreview, Attribute, Property, DocContainer, JavascriptDocs } from "@docutils";
+import { Datepicker as DatepickerComponent } from "@components/FormComponents";
+import Alert from "@components/Alert";
 
 const { datepicker } = window.px;
 

--- a/src/App/Documentation/components/Dialog/index.js
+++ b/src/App/Documentation/components/Dialog/index.js
@@ -1,9 +1,9 @@
 import React, { useEffect } from "react";
 import { Link } from "react-router-dom";
 
-import { ComponentPreview, DocContainer, Attribute, Property, JavascriptDocs } from "#";
-import AlertComponent from "@/Alert";
-import DialogComponent from "@/Dialog";
+import { ComponentPreview, DocContainer, Attribute, Property, JavascriptDocs } from "@docutils";
+import AlertComponent from "@components/Alert";
+import DialogComponent from "@components/Dialog";
 
 const { dialog } = window.px;
 

--- a/src/App/Documentation/components/Expandable/index.js
+++ b/src/App/Documentation/components/Expandable/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 
-import { ComponentPreview, DocContainer, Property } from "#";
-import ExpandableComponent from "@/Expandable";
+import { ComponentPreview, DocContainer, Property } from "@docutils";
+import ExpandableComponent from "@components/Expandable";
 
 const { expandable } = window.px;
 

--- a/src/App/Documentation/components/Footer/index.js
+++ b/src/App/Documentation/components/Footer/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 
-import { ComponentPreview, DocContainer, Property } from "#";
-import FooterComponent from "@/Footer";
+import { ComponentPreview, DocContainer, Property } from "@docutils";
+import FooterComponent from "@components/Footer";
 
 const Overview = () => (
     <>

--- a/src/App/Documentation/components/Forms/index.js
+++ b/src/App/Documentation/components/Forms/index.js
@@ -1,10 +1,10 @@
 import React, { Component } from "react";
 import PrismCode from "react-prism";
 
-import { ComponentPreview, DocContainer, Attribute, Property, PxScript, JavascriptDocs } from "#";
-import InputGroup from "@/InputGroup";
-import Button from "@/Button";
-import { Checkbox, FormControlText, Radio, Rangeslider, Togglebox } from "@/FormComponents";
+import { ComponentPreview, DocContainer, Attribute, Property, PxScript, JavascriptDocs } from "@docutils";
+import InputGroup from "@components/InputGroup";
+import Button from "@components/Button";
+import { Checkbox, FormControlText, Radio, Rangeslider, Togglebox } from "@components/FormComponents";
 
 const { rangeslider, validation } = window.px;
 

--- a/src/App/Documentation/components/InputGroup/index.js
+++ b/src/App/Documentation/components/InputGroup/index.js
@@ -1,8 +1,8 @@
 import React from "react";
 
-import { ComponentPreview, DocContainer, Property, Attribute } from "#";
+import { ComponentPreview, DocContainer, Property, Attribute } from "@docutils";
 import PrismCode from "react-prism";
-import InputGroupComponent from "@/InputGroup";
+import InputGroupComponent from "@components/InputGroup";
 
 const BasicExample = () => (
     <>

--- a/src/App/Documentation/components/Loaders/index.js
+++ b/src/App/Documentation/components/Loaders/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ComponentPreview, DocContainer, Property } from "#";
+import { ComponentPreview, DocContainer, Property } from "@docutils";
 
 const BasicUsage = () => (
     <>

--- a/src/App/Documentation/components/MediaObject/index.js
+++ b/src/App/Documentation/components/MediaObject/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 
-import { ComponentPreview, DocContainer, Property } from "#";
-import MediaObjectComponent from "@/MediaObject";
+import { ComponentPreview, DocContainer, Property } from "@docutils";
+import MediaObjectComponent from "@components/MediaObject";
 
 const Overview = () => (
     <>

--- a/src/App/Documentation/components/Nav/index.js
+++ b/src/App/Documentation/components/Nav/index.js
@@ -1,7 +1,7 @@
 import React, { useEffect } from "react";
 
-import { ComponentPreview, DocContainer, Property, JavascriptDocs } from "#";
-import NavComponent from "@/Nav";
+import { ComponentPreview, DocContainer, Property, JavascriptDocs } from "@docutils";
+import NavComponent from "@components/Nav";
 
 const { nav } = window.px;
 

--- a/src/App/Documentation/components/Pagination/index.js
+++ b/src/App/Documentation/components/Pagination/index.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PrismCode from "react-prism";
 
-import { ComponentPreview, DocContainer, Property } from "#";
-import PaginationComponent from "@/Pagination";
+import { ComponentPreview, DocContainer, Property } from "@docutils";
+import PaginationComponent from "@components/Pagination";
 
 const paginationItems = [
     /* eslint-disable object-property-newline */

--- a/src/App/Documentation/components/Panel/index.js
+++ b/src/App/Documentation/components/Panel/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 
-import { ComponentPreview, DocContainer, Property } from "#";
-import PanelComponent from "@/Panel";
+import { ComponentPreview, DocContainer, Property } from "@docutils";
+import PanelComponent from "@components/Panel";
 
 const bodyContent = [
     "Your main panel content is put here.",

--- a/src/App/Documentation/components/Sheet/index.js
+++ b/src/App/Documentation/components/Sheet/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 
-import { ComponentPreview, DocContainer, Property, JavascriptDocs } from "#";
-import SheetComponent from "@/Sheet";
+import { ComponentPreview, DocContainer, Property, JavascriptDocs } from "@docutils";
+import SheetComponent from "@components/Sheet";
 
 const { sheet } = window.px;
 

--- a/src/App/Documentation/components/Slab/index.js
+++ b/src/App/Documentation/components/Slab/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 
-import { ComponentPreview, DocContainer, Property } from "#";
+import { ComponentPreview, DocContainer, Property } from "@docutils";
 
 const { validation } = window.px;
 

--- a/src/App/Documentation/components/Status/index.js
+++ b/src/App/Documentation/components/Status/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 
-import { ComponentPreview, DocContainer, Property } from "#";
-import Alert from "@/Alert";
+import { ComponentPreview, DocContainer, Property } from "@docutils";
+import Alert from "@components/Alert";
 
 const Overview = () => (
     <>

--- a/src/App/Documentation/components/Steps/index.js
+++ b/src/App/Documentation/components/Steps/index.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PrismCode from "react-prism";
 
-import { ComponentPreview, DocContainer, Property } from "#";
-import StepsComponent from "@/Steps";
+import { ComponentPreview, DocContainer, Property } from "@docutils";
+import StepsComponent from "@components/Steps";
 
 const BasicSteps = () => {
     const steps = [

--- a/src/App/Documentation/components/Tabs/index.js
+++ b/src/App/Documentation/components/Tabs/index.js
@@ -2,8 +2,8 @@ import React, { Component } from "react";
 import { Link } from "react-router-dom";
 import PrismCode from "react-prism";
 
-import { ComponentPreview, DocContainer, Property, JavascriptDocs } from "#";
-import TabsComponent from "@/Tabs";
+import { ComponentPreview, DocContainer, Property, JavascriptDocs } from "@docutils";
+import TabsComponent from "@components/Tabs";
 
 const { tabs } = window.px;
 

--- a/src/App/Documentation/components/Toast/index.js
+++ b/src/App/Documentation/components/Toast/index.js
@@ -1,8 +1,8 @@
 import React, { Component } from "react";
 import { Link } from "react-router-dom";
 
-import { ComponentPreview, DocContainer, Attribute } from "#";
-import Alert from "@/Alert";
+import { ComponentPreview, DocContainer, Attribute } from "@docutils";
+import Alert from "@components/Alert";
 
 const Overview = () => (
     <>

--- a/src/App/Documentation/components/Tooltips/index.js
+++ b/src/App/Documentation/components/Tooltips/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ComponentPreview, DocContainer, Attribute } from "#";
+import { ComponentPreview, DocContainer, Attribute } from "@docutils";
 
 const Overview = () => (
     <>

--- a/src/App/Documentation/components/Topbar/index.js
+++ b/src/App/Documentation/components/Topbar/index.js
@@ -1,8 +1,8 @@
 import React, { Component } from "react";
 import PrismCode from "react-prism";
 
-import { ComponentPreview, DocContainer, Property, Attribute, JavascriptDocs } from "#";
-import TopbarComponent from "@/Topbar";
+import { ComponentPreview, DocContainer, Property, Attribute, JavascriptDocs } from "@docutils";
+import TopbarComponent from "@components/Topbar";
 
 const { topbar } = window.px;
 

--- a/src/App/Documentation/core/Breakpoints/index.js
+++ b/src/App/Documentation/core/Breakpoints/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { DocContainer, Property } from "#";
+import { DocContainer, Property } from "@docutils";
 
 const Overview = () => (
     <>

--- a/src/App/Documentation/core/Color/index.js
+++ b/src/App/Documentation/core/Color/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
-import { DocContainer } from "#";
+import { DocContainer } from "@docutils";
 import ColorPreview from "./ColorPreview";
 
 const mainText = [

--- a/src/App/Documentation/core/Favicons/index.js
+++ b/src/App/Documentation/core/Favicons/index.js
@@ -1,8 +1,8 @@
 import React from "react";
 import PrismCode from "react-prism";
 
-import { ComponentPreview, DocContainer, Attribute, Property } from "#";
-import Button from "@/Button";
+import { ComponentPreview, DocContainer, Attribute, Property } from "@docutils";
+import Button from "@components/Button";
 
 const BASENAME = process.env.basename;
 

--- a/src/App/Documentation/core/Grid/index.js
+++ b/src/App/Documentation/core/Grid/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
-import { ComponentPreview, DocContainer, Property } from "#";
+import { ComponentPreview, DocContainer, Property } from "@docutils";
 
 const HowItWorks = () => (
     <>

--- a/src/App/Documentation/core/Iconography/index.js
+++ b/src/App/Documentation/core/Iconography/index.js
@@ -1,8 +1,8 @@
 import React, { Component } from "react";
 import PrismCode from "react-prism";
 
-import { ComponentPreview, DocContainer, Property, Icon } from "#";
-import IconPreview from "@/IconPreview";
+import { ComponentPreview, DocContainer, Property, Icon } from "@docutils";
+import IconPreview from "@components/IconPreview";
 
 const { actionList } = window.px;
 

--- a/src/App/Documentation/core/Lists/index.js
+++ b/src/App/Documentation/core/Lists/index.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 
-import { ComponentPreview, DocContainer, Icon, Property } from "#";
+import { ComponentPreview, DocContainer, Icon, Property } from "@docutils";
 
 const { actionList } = window.px;
 

--- a/src/App/Documentation/core/Page-layout/index.js
+++ b/src/App/Documentation/core/Page-layout/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Link } from "react-router-dom";
-import { Property, ComponentPreview, DocContainer } from "#";
+import { Property, ComponentPreview, DocContainer } from "@docutils";
 
 const FullWidth = () => (
     <>

--- a/src/App/Documentation/core/Tables/index.js
+++ b/src/App/Documentation/core/Tables/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import classnames from "classnames";
 
-import { ComponentPreview, DocContainer } from "#";
+import { ComponentPreview, DocContainer } from "@docutils";
 
 const DocTable = ({ striped, condensed, hover }) => {
     const tableClasses = classnames(

--- a/src/App/Documentation/core/Typography/index.js
+++ b/src/App/Documentation/core/Typography/index.js
@@ -2,7 +2,7 @@ import React from "react";
 import { Link } from "react-router-dom";
 import PrismCode from "react-prism";
 
-import { ComponentPreview, DocContainer, Property } from "#";
+import { ComponentPreview, DocContainer, Property } from "@docutils";
 
 const Fonts = () => (
         <>

--- a/src/App/Documentation/dashboard/Charts/index.js
+++ b/src/App/Documentation/dashboard/Charts/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 
-import { ComponentPreview, DocContainer } from "#";
-import Chart from "@/Chart";
+import { ComponentPreview, DocContainer } from "@docutils";
+import Chart from "@components/Chart";
 
 const LineChart = () => (
         <>

--- a/src/App/Documentation/dashboard/Introduction/index.js
+++ b/src/App/Documentation/dashboard/Introduction/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PrismCode from "react-prism";
 
-import { ComponentPreview, Property, DocContainer } from "#";
+import { ComponentPreview, Property, DocContainer } from "@docutils";
 
 const BASENAME = process.env.basename;
 const scriptUrl = `https://design.swedbankpay.com${BASENAME}scripts/px-script.js`;

--- a/src/App/Documentation/getting-started/BrowserSupport/index.js
+++ b/src/App/Documentation/getting-started/BrowserSupport/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { DocContainer } from "#";
+import { DocContainer } from "@docutils";
 
 import Chrome from "./browser-icons/chrome.svg";
 import Firefox from "./browser-icons/firefox.svg";

--- a/src/App/Documentation/getting-started/Contributing/__snapshots__/index.test.js.snap
+++ b/src/App/Documentation/getting-started/Contributing/__snapshots__/index.test.js.snap
@@ -170,7 +170,7 @@ exports[`GettingStarted: Contributing Adding JavaScript renders 5`] = `
 import React, { Component } from "react";
 ...
 // import your components script
-import { MyExampleComponent } from "$/px-script/main";
+import { MyExampleComponent } from "@src/px-script/main";
 ...
 ...
 // modify MyExampleDocumentationComponent
@@ -362,8 +362,8 @@ exports[`GettingStarted: Contributing Create A Documentation Page renders 1`] = 
     
 //example documentation component
 import React from "react";
-import { ComponentPreview, DocContainer } from "#";
-import MyExampleComponent from "@/MyExampleComponent";
+import { ComponentPreview, DocContainer } from "@docutils";
+import MyExampleComponent from "@components/MyExampleComponent";
 const MyExampleDocumentationComponent = () =&gt; (
     &lt;DocContainer docToc&gt;
         &lt;p className="lead"&gt;This is the documentation for My Example Component.&lt;/p&gt;

--- a/src/App/Documentation/getting-started/Contributing/index.js
+++ b/src/App/Documentation/getting-started/Contributing/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PrismCode from "react-prism";
 
-import { ComponentPreview, DocContainer, Property } from "#";
+import { ComponentPreview, DocContainer, Property } from "@docutils";
 
 const CreatingYourComponent = () => (
     <>
@@ -38,8 +38,8 @@ const CreateADocumentationPage = () => (
             {`
 //example documentation component
 import React from "react";
-import { ComponentPreview, DocContainer } from "#";
-import MyExampleComponent from "@/MyExampleComponent";
+import { ComponentPreview, DocContainer } from "@docutils";
+import MyExampleComponent from "@components/MyExampleComponent";
 const MyExampleDocumentationComponent = () => (
     <DocContainer docToc>
         <p className="lead">This is the documentation for My Example Component.</p>
@@ -191,7 +191,7 @@ export { ... MyExampleComponent, ... }
 import React, { Component } from "react";
 ...
 // import your components script
-import { MyExampleComponent } from "$/px-script/main";
+import { MyExampleComponent } from "@src/px-script/main";
 ...
 ...
 // modify MyExampleDocumentationComponent

--- a/src/App/Documentation/getting-started/Introduction/index.js
+++ b/src/App/Documentation/getting-started/Introduction/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PrismCode from "react-prism";
 
-import { ComponentPreview, DocContainer } from "#";
+import { ComponentPreview, DocContainer } from "@docutils";
 
 const BASENAME = process.env.basename;
 const scriptUrl = `https://design.swedbankpay.com${BASENAME}scripts/px-script.js`;

--- a/src/App/Documentation/getting-started/Javascript/index.js
+++ b/src/App/Documentation/getting-started/Javascript/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 
-import { ComponentPreview, DocContainer, Property, PxScript } from "#";
-import Alert from "@/Alert";
+import { ComponentPreview, DocContainer, Property, PxScript } from "@docutils";
+import Alert from "@components/Alert";
 
 const AboutInit = () => (
     <>

--- a/src/App/Documentation/utilities/Borders/index.js
+++ b/src/App/Documentation/utilities/Borders/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { ComponentPreview, DocContainer, Property } from "#";
+import { ComponentPreview, DocContainer, Property } from "@docutils";
 
 const Overview = () => (
     <>

--- a/src/App/Documentation/utilities/Colors/index.js
+++ b/src/App/Documentation/utilities/Colors/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PrismCode from "react-prism";
 
-import { ComponentPreview, DocContainer, Property } from "#";
+import { ComponentPreview, DocContainer, Property } from "@docutils";
 
 const TextColors = () => (
     <>

--- a/src/App/Documentation/utilities/Display/index.js
+++ b/src/App/Documentation/utilities/Display/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
-import { ComponentPreview, DocContainer, Property } from "#";
+import { ComponentPreview, DocContainer, Property } from "@docutils";
 
 const HowItWorks = () => (
     <>

--- a/src/App/Documentation/utilities/Flex/index.js
+++ b/src/App/Documentation/utilities/Flex/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ComponentPreview, DocContainer, Property } from "#";
+import { ComponentPreview, DocContainer, Property } from "@docutils";
 
 const EnableFlexBehaviors = () => (
     <>

--- a/src/App/Documentation/utilities/Images/index.js
+++ b/src/App/Documentation/utilities/Images/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ComponentPreview, DocContainer, Property } from "#";
+import { ComponentPreview, DocContainer, Property } from "@docutils";
 
 const ImageFluid = () => (
     <>

--- a/src/App/Documentation/utilities/Sizing/index.js
+++ b/src/App/Documentation/utilities/Sizing/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ComponentPreview, Property, DocContainer } from "#";
+import { ComponentPreview, Property, DocContainer } from "@docutils";
 
 const Sizing = () => (
     <DocContainer>

--- a/src/App/Documentation/utilities/Spacing/index.js
+++ b/src/App/Documentation/utilities/Spacing/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ComponentPreview, DocContainer, Property } from "#";
+import { ComponentPreview, DocContainer, Property } from "@docutils";
 
 const HowItWorks = () => (
     <>

--- a/src/App/Documentation/utilities/Text/index.js
+++ b/src/App/Documentation/utilities/Text/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ComponentPreview, DocContainer, Property } from "#";
+import { ComponentPreview, DocContainer, Property } from "@docutils";
 
 const TextAlignment = () => (
     <>

--- a/src/App/Documentation/utilities/Visibility/index.js
+++ b/src/App/Documentation/utilities/Visibility/index.js
@@ -1,6 +1,6 @@
 import React from "react";
 
-import { ComponentPreview, Property, DocContainer } from "#";
+import { ComponentPreview, Property, DocContainer } from "@docutils";
 
 const Intro = () => (
     <>

--- a/src/App/Documentation/utils/DeprecatedComponentAlert/index.js
+++ b/src/App/Documentation/utils/DeprecatedComponentAlert/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Alert from "@/Alert";
+import Alert from "@components/Alert";
 
 const DeprecatedComponentAlert = () => (
     <Alert type="danger">

--- a/src/App/Documentation/utils/DocContainer/index.js
+++ b/src/App/Documentation/utils/DocContainer/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { DocToc, DocHeading } from "#";
+import { DocToc, DocHeading } from "@docutils";
 
 const DocContainer = ({ docToc, children }) => {
     const DocContent = () => <div className={`doc-body ${docToc ? "col-lg-10" : "col-12"}`}>{children}</div>;

--- a/src/App/Documentation/utils/ExperimentalComponentAlert/index.js
+++ b/src/App/Documentation/utils/ExperimentalComponentAlert/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import Alert from "@/Alert";
+import Alert from "@components/Alert";
 
 const ExperimentalComponentAlert = () => (
     <Alert type="danger">

--- a/src/App/Documentation/utils/JavascriptDocs/index.js
+++ b/src/App/Documentation/utils/JavascriptDocs/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 
-import { PxScript } from "#";
+import { PxScript } from "@docutils";
 
 const OpenDocs = ({ componentName }) => (
     <>

--- a/src/App/Documentation/utils/RenderRoutes/index.js
+++ b/src/App/Documentation/utils/RenderRoutes/index.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import { Switch, Route, Redirect } from "react-router-dom";
 import Loadable from "react-loadable";
 
-import { LoadingComponent } from "$/App/utils";
+import { LoadingComponent } from "@src/App/utils";
 
 const RenderRoutes = ({ path, redirect, routes }) => (
     <Switch>

--- a/src/App/components/ActionList/index.js
+++ b/src/App/components/ActionList/index.js
@@ -1,7 +1,7 @@
 import React, { Fragment } from "react";
 import PropTypes from "prop-types";
 
-import { Icon } from "#";
+import { Icon } from "@docutils";
 
 const ActionList = ({ id, classNames, toggleBtn, items }) => (
     <>

--- a/src/App/components/Alert/index.js
+++ b/src/App/components/Alert/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { Icon } from "#";
+import { Icon } from "@docutils";
 
 const Alert = ({ id, type, icon, close, text, children }) => (
     <div id={id} className={`alert alert-${type}`}>{icon ? "\n" : ""}

--- a/src/App/components/Dialog/index.js
+++ b/src/App/components/Dialog/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { Icon } from "#";
+import { Icon } from "@docutils";
 
 const Dialog = ({ diaId, diaHeader, children }) => (
     <>

--- a/src/App/components/FormComponents/Datepicker.js
+++ b/src/App/components/FormComponents/Datepicker.js
@@ -1,6 +1,6 @@
 import React from "react";
 import PropTypes from "prop-types";
-import { Addon } from "@/InputGroup";
+import { Addon } from "@components/InputGroup";
 
 const Datepicker = ({ format, time, min, max, months, value, label, prefixValue, prefixType, fulldate, mode, allowinput, required, id }) => {
     const attrs = {

--- a/src/App/components/Sheet/index.js
+++ b/src/App/components/Sheet/index.js
@@ -1,7 +1,7 @@
 import React from "react";
 import PropTypes from "prop-types";
 
-import { Icon } from "#";
+import { Icon } from "@docutils";
 
 const Sheet = ({ id, requireAction, children }) => (
     <div className="sheet" id={id} data-require-action={requireAction ? true : null}>

--- a/src/App/components/Topbar/index.js
+++ b/src/App/components/Topbar/index.js
@@ -1,6 +1,6 @@
 import React, { Fragment } from "react";
 import PropTypes from "prop-types";
-import logo from "$/img/logo/spay_horizontal_pos.svg";
+import logo from "@src/img/logo/spay_horizontal_pos.svg";
 
 const isDev = process.env.version === "LOCAL_DEV";
 

--- a/src/App/index.js
+++ b/src/App/index.js
@@ -3,7 +3,7 @@ import { Router, Switch, Route, withRouter } from "react-router-dom";
 import { createBrowserHistory } from "history";
 import Loadable from "react-loadable";
 
-import Footer from "@/Footer";
+import Footer from "@components/Footer";
 import AppHeader from "./AppHeader";
 import { LoadingComponent } from "./utils";
 

--- a/src/px-script/main/alert/index.test.js
+++ b/src/px-script/main/alert/index.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 import alert from "./index";
-import Alert from "@/Alert";
+import Alert from "@components/Alert";
 
 describe("px-script: alert", () => {
     const div = document.createElement("div");

--- a/src/px-script/main/datepicker/index.test.js
+++ b/src/px-script/main/datepicker/index.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 import datepicker from "./index";
-import Datepicker from "@/FormComponents/Datepicker";
+import Datepicker from "@components/FormComponents/Datepicker";
 import formats from "./formats";
 
 // TODO: rewrite tests to mock flatpickr [AW]

--- a/src/px-script/main/index.js
+++ b/src/px-script/main/index.js
@@ -1,5 +1,5 @@
 import { init } from "~/node_modules/@sentry/browser";
-import "$/polyfills";
+import "@src/polyfills";
 
 import actionList from "./action-list";
 import alert from "./alert";

--- a/src/px-script/main/tabs/index.test.js
+++ b/src/px-script/main/tabs/index.test.js
@@ -2,7 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom";
 
 import tabs from "./index";
-import TabsComponent from "@/Tabs";
+import TabsComponent from "@components/Tabs";
 
 describe("px-script: tabs", () => {
     const div = document.createElement("div");


### PR DESCRIPTION
Update import aliases to something readable.

The following imports are hard to read unless you've memorized the readme file.
`import { Foo } from "#"`
`import { Bar } from "$"`
`import { FooterComponent } from "@/Footer"`

This PR updates the imports into
`import { Foo } from "@docutils"`
`import { Bar} from "@src"`
`import { FooterComponent } from "@components/Footer"`

the `~` alias remains the same because it is an universal alias.
