### PR TITLE
Tidy up and add image to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# Swedbank Pay DesignGuide
+# Swedbank Pay Design Guide
 
 [![Version][version-badge]][version-tag]
 [![Build status][appveyor-badge]][appveyor-status]
 [![Codecov][codecov-badge]][codecov-status]
-[![Dependabot Status][dependabot-badge]][dependabot-status]
+[![Dependabot Status][dependabot-badge]][dependabot]
 [![Dependencies Status][dep-badge]][dep-status]
 [![devDependencies Status][devdep-badge]][devdep-status]
 
@@ -11,11 +11,12 @@
 
 ## Installing / Getting started
 
-The following guides are for further development of the DesignGuide, and are not necessary if you only plan to use the DesignGuide in your project.
+The following guides are for further development of the Design Guide, and are
+not necessary if you only plan to use the Design Guide in your project.
 
 ### Prerequisites
 
-DesignGuide requires [Node.js][nodejs] (includes npm).
+Design Guide requires [Node.js][nodejs] (includes npm).
 
 ### Installing
 
@@ -23,7 +24,8 @@ DesignGuide requires [Node.js][nodejs] (includes npm).
 2. `npm ci`
 3. `npm start`
 4. Go to `http://localhost:3000`
-5. Works? If not, contact us on Slack ([`#design-guide-general`][slack] – only available to Swedbank Pay and PayEx employees).
+5. Works? If not, contact us on Slack ([`#design-guide-general`][slack] – only
+   available to Swedbank Pay and PayEx employees).
 6. Get to work.
 
 ### Set up Git Hooks
@@ -33,7 +35,12 @@ DesignGuide requires [Node.js][nodejs] (includes npm).
 
 ## Developing
 
-It is important to note that as a developer, this project supports two brands: **Swedbank Pay** _and_ **PayEx**. [Webpack][webpack] is configured to accept a brand flag which is used to collect different sets of theme variables. **Swedbank Pay** is default flag. E.g. `npm start` sets the theme to **Swedbank Pay**, while `npm run start:payex` sets the theme to... you guessed it, **PayEx**. Check out the `package.json` file for additional scripts.
+It is important to note that as a developer, this project supports two brands:
+**Swedbank Pay** _and_ **PayEx**. [Webpack][webpack] is configured to accept a
+brand flag which is used to collect different sets of theme variables.
+**Swedbank Pay** is default flag. E.g. `npm start` sets the theme to
+**Swedbank Pay**, while `npm run start:payex` sets the theme to … you guessed
+it, **PayEx**. Check out the `package.json` file for additional scripts.
 
 ### Built with
 
@@ -42,49 +49,75 @@ It is important to note that as a developer, this project supports two brands: *
 
 ### Setting up Dev
 
-- Running the command `npm start` starts the Webpack dev server, (which is configured in `~/webpack.config.js`). If any changes is made to this file, or any files directly influencing this file (i.e. any loaders or plugins) you need to restart the server.
-- The script `npm start` will start the dev server in development mode. If you wish to run the dev server in production-like environment run the command `npm run start:prod`.
+- Running the command `npm start` starts the Webpack dev server, (which is
+  configured in `~/webpack.config.js`). If any changes is made to this file, or
+  any files directly influencing this file (i.e. any loaders or plugins) you
+  need to restart the server.
+- The script `npm start` will start the dev server in development mode. If you
+  wish to run the dev server in production-like environment run the command
+  `npm run start:prod`.
 
 #### Importing components
 
-When importing different components in the files you create, you can use shortcuts for common paths. The shortcuts are as following:
+When importing different components in the files you create, you can use
+shortcuts for common paths. The shortcuts are as following:
 
-- `~` - root of the project (example `import package from "~/package";`).
-- `$` - `~/src`-folder (example `import dg from "$/scripts";`).
-- `@` - `~/src/App/components`-folder (example `import Alert from "@components/Alert";`).
-- `#` - `~/src/App/Documentation/utils`-folder (example `import { DocToc } from "@docutils";`).
+| Shortcut | Description |
+|:--------:|:------------|
+|   `~`    | root of the project (example `import package from "~/package";`)
+|   `$`    | `~/src`-folder (example `import dg from "$/scripts";`)
+|   `@`    |  `~/src/App/components`-folder (example `import Alert from "@components/Alert";`)
+|   `#`    | `~/src/App/Documentation/utils`-folder (example `import { DocToc } from "@docutils";`)
 
-The shortcuts are specified in the `~/.babelrc`-file. Specifying the prefix-shortcuts in the `~/jsconfig.json`-file enables path intellisense for the shortcuts (at least in VSCode).
+The shortcuts are specified in the `~/.babelrc`-file. Specifying the
+prefix-shortcuts in the `~/jsconfig.json`-file enables path intellisense for
+the shortcuts (at least in VSCode).
 
 ### Building
 
-To start building, run the command `npm run build` to start in dev-mode, or `npm run build:prod` for production-mode. This will make webpack start bundling everything and make static files in the `~/dist/`-folder. Also make sure all tests pass, or make changes to them accordingly.
-> Note: Running the command `npm run build:prod` will delete all files already located in `~/dist`.
+To start building, run the command `npm run build` to start in dev-mode, or
+`npm run build:prod` for production-mode. This will make webpack start bundling
+everything and make static files in the `~/dist/`-folder. Also make sure all
+tests pass, or make changes to them accordingly.
+
+> Note: Running the command `npm run build:prod` will delete all files already
+> located in `~/dist`.
 
 ## Versioning
 
-DesignGuide uses [semantic versioning][semver]. This means that internally, DesignGuide will use a `major.minor.patch` version number to signal what the changes in each release surmount to. This also means both CSS and JavaScript files are versioned in lockstep, so whenever a new version of the CSS is released, a new version of the JavaScript will be as well.
+Design Guide uses [semantic versioning][semver]. This means that internally,
+Design Guide will use a `major.minor.patch` version number to signal what the
+changes in each release surmount to. This also means both CSS and JavaScript
+files are versioned in lockstep, so whenever a new version of the CSS is
+released, a new version of the JavaScript will be as well.
 
 ## Tests
 
 1. Open a terminal and navigate to repo root
 2. Run the command `npm test`
-    - Many of the tests are snapshot based, and runs against already created snapshots. If you need to update the snapshots due to changes run the command `npm run test:update`.
-    - A test coverage report is generated after running the tests. This can be found in `~/coverage`.
+    - Many of the tests are snapshot based, and runs against already created
+      snapshots. If you need to update the snapshots due to changes run the
+      command `npm run test:update`.
+    - A test coverage report is generated after running the tests. This can be
+      found in `~/coverage`.
 
-> Note: Snapshot testing is pretty unforgiving, so if you make __ANY__ changes to how a component, which already has a snapshot, is rendered, the tests __WILL__ crash! So make sure to run `npm run test:update` before committing.
+> Note: Snapshot testing is pretty unforgiving, so if you make __ANY__ changes
+> to how a component, which already has a snapshot, is rendered, the tests
+> __WILL__ crash! So make sure to run `npm run test:update` before committing.
 
 ## Code style
 
-Coding style rules set in `~/.eslintrc` & `~/.stylelintrc`.
+Coding style rules are set in `~/.eslintrc` & `~/.stylelintrc`.
 
 __*Make sure to follow the syntax rules enforced by ESLint & Stylelint.*__
 
 ## Contributing
 
 - Bug reports: File bugs as Github [issues][issues].
-- Feature suggestions: File as Github issue or discuss the feature on Slack ([`#design-guide-general`][slack]).
-- Code contributions: Code contributions are highly encouraged, but discuss the feature/bugfix in an issue or on Slack before you start coding.
+- Feature suggestions: File as Github issue or discuss the feature on Slack
+  ([`#design-guide-general`][slack]).
+- Code contributions: Code contributions are highly encouraged, but discuss
+  the feature/bugfix in an issue or on Slack before you start coding.
 
 ## Creating a release
 
@@ -92,17 +125,22 @@ Before merging to master to create a release, make sure you follow these steps:
 
 1. Make sure the linting (`npm run lint`) and unit tests pass (`npm test`).
 2. Update the version in `~/package.json`.
-3. Make sure the changelog is correct (date and version) and only contains changes for the current release.
-4. Update the version in the url to the shield image at the top of this `README.md`.
-5. Commit the changes and create a pull request to `develop`.
-6. When approved and merged, create a new pull request from `develop` to `master`.
+3. Make sure the changelog is correct (date and version) and only contains
+   changes for the current release.
+4. Update the version in the URL of the `version-badge` and `version-tag`
+   at the bottom of this `README.md` file.
+5. Commit the changes and create a pull request from your branch to `develop`.
+6. When approved and merged, create a new pull request from `develop` to
+   `master`.
 7. When approved, rename the merge commit to `Release x.x.x` and merge.
 8. Change branch to `master`.
 9. Create and push a new tag with the new release commit.
 
-AppVeyor will now create and deploy a release on both github and [`design.swedbankpay.com`][swpdg].
+AppVeyor will now create and deploy a release on both github and
+[`design.swedbankpay.com`][swpdg].
 
-After pushing to master, create a pull request to `develop` that deletes the changelog content but keeps the headers.
+After pushing to master, create a pull request to `develop` that deletes the
+changelog content but keeps the headers.
 
 ## Core development team
 
@@ -112,24 +150,27 @@ After pushing to master, create a pull request to `develop` that deletes the cha
 
 ## Contents of this project
 
-- `~/coverage` - Test coverage report for the project (not commited to repo).
-- `~/dist` - Static files generated by [Webpack][webpack] (not commited to repo).
-- `~/src` - All the source files.
-- `~/build` - Config files for [AppVeyor][appveyor], and other files required for the AppVeyor build process.
-- `~/tools` - Various tools, mostly related to the build/deploy process.
+| Folder        | Description |
+|:--------------|:------------|
+| `~/coverage`  | Test coverage report for the project (not commited to the repository).
+| `~/dist`      | Static files generated by [Webpack][webpack] (not commited to the repository).
+| `~/src`       | All the source files.
+| `~/build`     | Config files for [AppVeyor][appveyor], and other files required for the AppVeyor build process.
+| `~/tools`     | Various tools, mostly related to the build/deploy process.
 
 ## Notable files
 
-- `.babelrc` - [Babel][babel] configuration.
-- `.eslintignore` - List of files/directories ESLint will ignore (similar to `.gitignore`).
-- `.eslintrc` - [Eslint][eslint] configuration.
-- `.sentryclirc` - [Sentry][sentry] configuration used by Webpack to configure a new release on sentry.
-    - _Do __not__ change the line `token = <token>`, as this placeholder is used by AppVeyor to insert the sentry api key._
-- `.stylelintrc` - [Stylelint][stylelint] configuration.
-- `CHANGELOG.md` - Collection of changes made to the project. Insert your changes here.
-- `jest.config.js` - [jest][jest] configuration.
-- `jest.setup.js` - Script file that will run before jest executes the tests, this includes [enzyme][enzyme] setup, polyfills and other useful snippets.
-- `webpack.config.js` - [Webpack][webpack] configuration.
+| File                | Description |
+|:--------------------|:------------|
+| `.babelrc`          | [Babel][babel] configuration.
+| `.eslintignore`     | List of files/directories ESLint will ignore (similar to `.gitignore`)
+| `.eslintrc`         | [Eslint][eslint] configuration.
+| `.sentryclirc`      | [Sentry][sentry] configuration used by Webpack to configure a new release on sentry. _(Do __not__ change the line `token = <token>`, as this placeholder is used by AppVeyor to insert the sentry api key.)_
+| `.stylelintrc`      | [Stylelint][stylelint] configuration.
+| `CHANGELOG.md`      | Collection of changes made to the project. Insert your changes here.
+| `jest.config.js`    | [jest][jest] configuration.
+| `jest.setup.js`     | Script file that will run before jest executes the tests, this includes [enzyme][enzyme] setup, polyfills and other useful snippets.
+| `webpack.config.js` | [Webpack][webpack] configuration.
 
 ## Copyright, license and credits
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Swedbank Pay DesignGuide
 
-[![Version](https://img.shields.io/badge/Version-4.1.0-blue.svg)](https://github.com/swedbankpay/design.swedbankpay.com/releases/tag/4.1.0)
-[![Build status](https://ci.appveyor.com/api/projects/status/1dii19sqw1m7xtsn/branch/master?svg=true)](https://ci.appveyor.com/project/PayEx/design-swedbankpay-com/branch/master)
-[![codecov](https://codecov.io/gh/swedbankpay/design.swedbankpay.com/branch/develop/graph/badge.svg)](https://codecov.io/gh/swedbankpay/design.swedbankpay.com)
-[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=SwedbankPay/design.swedbankpay.com)](https://dependabot.com)
-[![dependencies Status](https://david-dm.org/swedbankpay/design.swedbankpay.com/status.svg)](https://david-dm.org/swedbankpay/design.swedbankpay.com)
-[![devDependencies Status](https://david-dm.org/swedbankpay/design.swedbankpay.com/dev-status.svg)](https://david-dm.org/swedbankpay/design.swedbankpay.com?type=dev)
+[![Version][version-badge]][version-tag]
+[![Build status][appveyor-badge]][appveyor-status]
+[![Codecov][codecov-badge]][codecov-status]
+[![Dependabot Status][dependabot-badge]][dependabot-status]
+[![Dependencies Status][dep-badge]][dep-status]
+[![devDependencies Status][devdep-badge]][devdep-status]
 
-[![Swedbank Pay Design Guide](https://repository-images.githubusercontent.com/191536903/a4653c80-e7ac-11e9-9d96-c5bf40f73d9c)](https://design.swedbankpay.com)
+[![Swedbank Pay Design Guide][og-image]][swpdg]
 
 ## Installing / Getting started
 
@@ -15,15 +15,15 @@ The following guides are for further development of the DesignGuide, and are not
 
 ### Prerequisites
 
-DesignGuide requires [Node.js](https://nodejs.org/en/) (includes npm).
+DesignGuide requires [Node.js][nodejs] (includes npm).
 
 ### Installing
 
 1. Open a terminal and navigate to repo root
 2. `npm ci`
 3. `npm start`
-4. Go to <http://localhost:3000>
-5. Works? If not, contact us on Slack ([#design-guide-general](https://payex.slack.com/messages/C0L3W8B2S/)).
+4. Go to `http://localhost:3000`
+5. Works? If not, contact us on Slack ([`#design-guide-general`][slack] – only available to Swedbank Pay and PayEx employees).
 6. Get to work.
 
 ### Set up Git Hooks
@@ -33,16 +33,16 @@ DesignGuide requires [Node.js](https://nodejs.org/en/) (includes npm).
 
 ## Developing
 
-It is important to note that as a developer, this project supports two brands: **Swedbank Pay** _and_ **PayEx**. Webpack is configured to accept a brand flag which is used to collect different sets of theme variables. **Swedbank Pay** is default flag. E.g. `npm start` sets the theme to **Swedbank Pay**, while `npm run start:payex` sets the theme to... you guessed it, **PayEx**. Check out the `package.json` file for additional scripts.
+It is important to note that as a developer, this project supports two brands: **Swedbank Pay** _and_ **PayEx**. [Webpack][webpack] is configured to accept a brand flag which is used to collect different sets of theme variables. **Swedbank Pay** is default flag. E.g. `npm start` sets the theme to **Swedbank Pay**, while `npm run start:payex` sets the theme to... you guessed it, **PayEx**. Check out the `package.json` file for additional scripts.
 
 ### Built with
 
-- [React](https://reactjs.org/)
-- [Less](http://lesscss.org/)
+- [React][react]
+- [Less][less]
 
 ### Setting up Dev
 
-- Running the command `npm start` starts the webpack dev server, (which is configured in `~/webpack.config.js`). If any changes is made to this file, or any files directly influencing this file (i.e. any loaders or plugins) you need to restart the server.
+- Running the command `npm start` starts the Webpack dev server, (which is configured in `~/webpack.config.js`). If any changes is made to this file, or any files directly influencing this file (i.e. any loaders or plugins) you need to restart the server.
 - The script `npm start` will start the dev server in development mode. If you wish to run the dev server in production-like environment run the command `npm run start:prod`.
 
 #### Importing components
@@ -63,7 +63,7 @@ To start building, run the command `npm run build` to start in dev-mode, or `npm
 
 ## Versioning
 
-DesignGuide uses [semantic versioning](http://semver.org/). This means that internally, DesignGuide will use a `major.minor.patch` version number to signal what the changes in each release surmount to. This also means both CSS and JavaScript files are versioned in lockstep, so whenever a new version of the CSS is released, a new version of the JavaScript will be as well.
+DesignGuide uses [semantic versioning][semver]. This means that internally, DesignGuide will use a `major.minor.patch` version number to signal what the changes in each release surmount to. This also means both CSS and JavaScript files are versioned in lockstep, so whenever a new version of the CSS is released, a new version of the JavaScript will be as well.
 
 ## Tests
 
@@ -71,67 +71,102 @@ DesignGuide uses [semantic versioning](http://semver.org/). This means that inte
 2. Run the command `npm test`
     - Many of the tests are snapshot based, and runs against already created snapshots. If you need to update the snapshots due to changes run the command `npm run test:update`.
     - A test coverage report is generated after running the tests. This can be found in `~/coverage`.
+
 > Note: Snapshot testing is pretty unforgiving, so if you make __ANY__ changes to how a component, which already has a snapshot, is rendered, the tests __WILL__ crash! So make sure to run `npm run test:update` before committing.
 
 ## Code style
 
 Coding style rules set in `~/.eslintrc` & `~/.stylelintrc`.
 
-__*Make sure to follow the syntax rules enforced by eslint & stylelint.*__
+__*Make sure to follow the syntax rules enforced by ESLint & Stylelint.*__
 
 ## Contributing
 
-- Bug reports: File bugs as Github [issues](https://github.com/swedbankpay/design.swedbankpay.com/issues).
-- Feature suggestions: File as Github issue or discuss the feature on Slack ([#design-guide-general](https://payex.slack.com/messages/C0L3W8B2S/)).
-- Code contribtions: Code contribtions are highly encouraged, but discuss the feature/bugfix in an issue or on Slack before you start coding.
+- Bug reports: File bugs as Github [issues][issues].
+- Feature suggestions: File as Github issue or discuss the feature on Slack ([`#design-guide-general`][slack]).
+- Code contributions: Code contributions are highly encouraged, but discuss the feature/bugfix in an issue or on Slack before you start coding.
 
 ## Creating a release
 
-Before merging to master to create a release make sure you follow these steps:
+Before merging to master to create a release, make sure you follow these steps:
 
 1. Make sure the linting (`npm run lint`) and unit tests pass (`npm test`).
-2. Update the version in `~/package.json`
-3. Make sure the changelog is correct (date and version) and only contains changes for the current release
-4. Update the version in the url to the shield image at the top of this `README.md`
-5. Commit the changes and create a pull request to `develop`
-6. When approved and merged, create a new pull request from `develop` to `master`
-7. When approved, rename the merge commit to `Release x.x.x` and merge
-8. Change branch to `master` 
-9. Create and push a new tag with the new release commit
+2. Update the version in `~/package.json`.
+3. Make sure the changelog is correct (date and version) and only contains changes for the current release.
+4. Update the version in the url to the shield image at the top of this `README.md`.
+5. Commit the changes and create a pull request to `develop`.
+6. When approved and merged, create a new pull request from `develop` to `master`.
+7. When approved, rename the merge commit to `Release x.x.x` and merge.
+8. Change branch to `master`.
+9. Create and push a new tag with the new release commit.
 
-AppVeyor will now create and deploy a release on both github and [design.swedbankpay.com](https://design.swedbankpay.com).
+AppVeyor will now create and deploy a release on both github and [`design.swedbankpay.com`][swpdg].
 
 After pushing to master, create a pull request to `develop` that deletes the changelog content but keeps the headers.
 
-## Involved developers
+## Core development team
 
-- [Erik Hallaraaker](https://github.com/erikhallaraaker)
-- [Håkon Mosvoll](https://github.com/hmosvoll)
-- [Thomas Lorntzen](https://github.com/VikingTristan)
+- [Erik Hallaraaker][erikhallaraaker]
+- [Håkon Mosvoll][hmosvoll]
+- [Thomas Lorntzen][VikingTristan]
 
 ## Contents of this project
 
 - `~/coverage` - Test coverage report for the project (not commited to repo).
-- `~/dist` - Static files generated by [webpack](https://webpack.js.org/) (not commited to repo).
+- `~/dist` - Static files generated by [Webpack][webpack] (not commited to repo).
 - `~/src` - All the source files.
-- `~/build` - Config files for [AppVeyor](https://www.appveyor.com/), and other files required for the AppVeyor build process.
+- `~/build` - Config files for [AppVeyor][appveyor], and other files required for the AppVeyor build process.
 - `~/tools` - Various tools, mostly related to the build/deploy process.
 
 ## Notable files
 
-- `.babelrc` - [Babel](https://babeljs.io/) configuration.
-- `.eslintignore` - List of files/directories eslint will ignore (similar to .gitignore).
-- `.eslintrc` - [Eslint](https://eslint.org/) configuration.
-- `.sentryclirc` - [Sentry](https://sentry.io) configuration used by webpack to configure a new release on sentry.
+- `.babelrc` - [Babel][babel] configuration.
+- `.eslintignore` - List of files/directories ESLint will ignore (similar to `.gitignore`).
+- `.eslintrc` - [Eslint][eslint] configuration.
+- `.sentryclirc` - [Sentry][sentry] configuration used by Webpack to configure a new release on sentry.
     - _Do __not__ change the line `token = <token>`, as this placeholder is used by AppVeyor to insert the sentry api key._
-- `.stylelintrc` - [Stylelint](https://stylelint.io/) configuration.
+- `.stylelintrc` - [Stylelint][stylelint] configuration.
 - `CHANGELOG.md` - Collection of changes made to the project. Insert your changes here.
-- `jest.config.js` - [jest](https://facebook.github.io/jest/) configuration.
-- `jest.setup.js` - Script file that will run before jest executes the tests, this includes [enzyme](http://airbnb.io/enzyme/) setup, polyfills and other useful snippets.
-- `webpack.config.js` - [Webpack](https://webpack.js.org/) configuration.
+- `jest.config.js` - [jest][jest] configuration.
+- `jest.setup.js` - Script file that will run before jest executes the tests, this includes [enzyme][enzyme] setup, polyfills and other useful snippets.
+- `webpack.config.js` - [Webpack][webpack] configuration.
 
 ## Copyright, license and credits
 
 Code and documentation © Swedbank Pay and contributors, released under the [MIT License](LICENSE).
 
-Inspired by [Bootstrap](http://getbootstrap.com/) and [Materialize](https://materializecss.com/).
+Inspired by [Bootstrap][bootstrap] and [Materialize][materialize].
+
+  [version-badge]:      https://img.shields.io/badge/Version-4.1.0-blue.svg
+  [version-tag]:        https://github.com/swedbankpay/design.swedbankpay.com/releases/tag/4.1.0
+  [appveyor-badge]:     https://ci.appveyor.com/api/projects/status/1dii19sqw1m7xtsn/branch/master?svg=true
+  [appveyor-status]:    https://ci.appveyor.com/project/PayEx/design-swedbankpay-com/branch/master
+  [appveyor]:           https://www.appveyor.com/
+  [codecov-badge]:      https://codecov.io/gh/swedbankpay/design.swedbankpay.com/branch/develop/graph/badge.svg
+  [codecov-status]:     https://codecov.io/gh/swedbankpay/design.swedbankpay.com
+  [dependabot-badge]:   https://api.dependabot.com/badges/status?host=github&repo=SwedbankPay/design.swedbankpay.com
+  [dependabot]:         https://dependabot.com
+  [dep-badge]:          https://david-dm.org/swedbankpay/design.swedbankpay.com/status.svg
+  [dep-status]:         https://david-dm.org/swedbankpay/design.swedbankpay.com
+  [devdep-badge]:       https://david-dm.org/swedbankpay/design.swedbankpay.com/dev-status.svg
+  [devdep-status]:      https://david-dm.org/swedbankpay/design.swedbankpay.com?type=dev
+  [og-image]:           https://repository-images.githubusercontent.com/191536903/a4653c80-e7ac-11e9-9d96-c5bf40f73d9c
+  [swpdg]:              https://design.swedbankpay.com
+  [nodejs]:             https://nodejs.org/en/
+  [slack]:              https://payex.slack.com/messages/C0L3W8B2S/
+  [react]:              https://reactjs.org/
+  [less]:               http://lesscss.org/
+  [webpack]:            https://webpack.js.org/
+  [semver]:             http://semver.org/
+  [issues]:             https://github.com/swedbankpay/design.swedbankpay.com/issues
+  [erikhallaraaker]:    https://github.com/erikhallaraaker
+  [hmosvoll]:           https://github.com/hmosvoll
+  [VikingTristan]:      https://github.com/VikingTristan
+  [babel]:              https://babeljs.io/
+  [eslint]:             https://eslint.org/
+  [sentry]:             https://sentry.io
+  [stylelint]:          https://stylelint.io/
+  [jest]:               https://facebook.github.io/jest/
+  [enzyme]:             http://airbnb.io/enzyme/
+  [bootstrap]:          http://getbootstrap.com/
+  [materialize]:        https://materializecss.com/

--- a/README.md
+++ b/README.md
@@ -1,10 +1,3 @@
-<p align="center">
-    <img src="./src/img/swedbankpay/logo/swedbankpay-logo.svg" width=300 />
-</p>
-<p align="center">
-    <img src="./src/img/payex/logo/payex-logo.svg" width=140 />
-</p>
-
 # Swedbank Pay DesignGuide
 
 [![Version](https://img.shields.io/badge/Version-4.1.0-blue.svg)](https://github.com/swedbankpay/design.swedbankpay.com/releases/tag/4.1.0)
@@ -13,6 +6,8 @@
 [![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=SwedbankPay/design.swedbankpay.com)](https://dependabot.com)
 [![dependencies Status](https://david-dm.org/swedbankpay/design.swedbankpay.com/status.svg)](https://david-dm.org/swedbankpay/design.swedbankpay.com)
 [![devDependencies Status](https://david-dm.org/swedbankpay/design.swedbankpay.com/dev-status.svg)](https://david-dm.org/swedbankpay/design.swedbankpay.com?type=dev)
+
+[![Swedbank Pay Design Guide](https://repository-images.githubusercontent.com/191536903/a4653c80-e7ac-11e9-9d96-c5bf40f73d9c)](https://design.swedbankpay.com)
 
 ## Installing / Getting started
 


### PR DESCRIPTION
## Description

This PR adds an illustrative title image to the repository and tidies up the readme a bit so it's easier to read in plain text and also uses more Markdown features such as tables to render to more readable HTML.

## Motivation and Context
I wanted to add an illustrative image and thought the Markdown in the readme could use some help.

## How Has This Been Tested?
The changes passes markdownlint if that means anything. :)

## Screenshots (if appropriate):

![Swedbank Pay Design Guide](https://repository-images.githubusercontent.com/191536903/a4653c80-e7ac-11e9-9d96-c5bf40f73d9c)

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
