### PR TITLE
Feature/tabs scroll state control

### DIFF
--- a/src/App/Documentation/components/Tabs/__snapshots__/index.test.js.snap
+++ b/src/App/Documentation/components/Tabs/__snapshots__/index.test.js.snap
@@ -55,6 +55,11 @@ exports[`Components: Tabs JavascriptMethods renders 1`] = `
   </h2>
   <JavascriptDocs
     componentName="tabs"
+    others={
+      Array [
+        [Function],
+      ]
+    }
   />
 </Fragment>
 `;

--- a/src/App/Documentation/components/Tabs/index.js
+++ b/src/App/Documentation/components/Tabs/index.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PrismCode from "react-prism";
 
-import { ComponentPreview, DocContainer, Property, JavascriptDocs } from "@docutils";
+import { ComponentPreview, DocContainer, Property, JavascriptDocs, DgScript, Attribute } from "@docutils";
 import TabsComponent from "@components/Tabs";
 
 const { tabs } = window.dg;
@@ -35,10 +35,24 @@ const TabsScroll = () => (
     </>
 );
 
+const SetScrollStateJavaScript = ({ componentName }) => (
+    <>
+        <tr>
+            <td scope="row"><DgScript component={componentName} func="setScrollState" params={[`<${componentName.toLowerCase()}-id>`, "scrollState"]} /></td>
+            <td>
+                Moves the scroll position of the {componentName} to the user specified position. The value to be passed to <Attribute name="scrollState" /> is
+                the object <Attribute name="{ scrollStart, scrollTotalAmount }" />. <Attribute name="scrollStart" /> is the current scroll
+                position, <Attribute name="scrollTotalAmount" /> is the amount to be scrolled from the current scroll position (negative values for left scroll,
+                positive values for right scroll).
+            </td>
+        </tr>
+    </>
+);
+
 const JavascriptMethods = () => (
     <>
         <h2 id="javascript-methods">JavaScript methods</h2>
-        <JavascriptDocs componentName="tabs" />
+        <JavascriptDocs componentName="tabs" others={[SetScrollStateJavaScript]} />
     </>
 );
 

--- a/src/App/Documentation/utils/JavascriptDocs/index.js
+++ b/src/App/Documentation/utils/JavascriptDocs/index.js
@@ -21,7 +21,7 @@ const CloseDocs = ({ componentName }) => (
     </>
 );
 
-const JavascriptDocs = ({ componentName, open, close }) => (
+const JavascriptDocs = ({ componentName, open, close, others }) => (
     <>
         <table className="table table-striped">
             <thead>
@@ -37,6 +37,7 @@ const JavascriptDocs = ({ componentName, open, close }) => (
                 </tr>
                 {open ? <OpenDocs componentName={componentName} /> : null}
                 {close ? <CloseDocs componentName={componentName} /> : null}
+                {others && others.map((DocComponent, i) => <DocComponent key={i} componentName={componentName} />)}
             </tbody>
         </table>
     </>

--- a/src/scripts/main/tabs/index.js
+++ b/src/scripts/main/tabs/index.js
@@ -18,13 +18,9 @@ class Tabs {
             // Only move scrollbar when interacting with the tab elements
             if (e.target.tagName === "A") {
                 const scrollStart = this.openUl.scrollLeft;
-                const scrollTotalAmount = (e.target.offsetLeft - (this.openUl.offsetWidth / 2) + (e.target.offsetWidth / 2)) - scrollStart;
-                let scrolledCount = 0;
-                const smoothTabScroll = setInterval(() => {
-                    this.openUl.scrollLeft += scrollTotalAmount / 10;
-                    scrolledCount = scrolledCount + 1;
-                    (scrolledCount === 10) && window.clearInterval(smoothTabScroll);
-                }, 5);
+                const scrollTotalAmount = (e.target.offsetLeft - (this._el.offsetWidth / 2) + (e.target.offsetWidth / 2)) - scrollStart;
+
+                this.scrollTabs(scrollStart, scrollTotalAmount);
             }
         });
 
@@ -41,6 +37,17 @@ class Tabs {
         }
 
         this._addListener();
+    }
+
+    scrollTabs (scrollStart, scrollTotalAmount) {
+        this.openUl.scrollLeft = scrollStart;
+
+        let scrolledCount = 0;
+        const smoothTabScroll = setInterval(() => {
+            this.openUl.scrollLeft += scrollTotalAmount / 10;
+            scrolledCount = scrolledCount + 1;
+            (scrolledCount === 10) && window.clearInterval(smoothTabScroll);
+        }, 5);
     }
 
     _addListener () {
@@ -101,6 +108,24 @@ const init = id => {
     }
 };
 
+const setScrollState = (id, scrollState) => {
+
+    let tab = null;
+
+    _tabs.forEach(t => t.id === id && (tab = t));
+
+    try {
+        tab.scrollTabs(scrollState.scrollStart, scrollState.scrollTotalAmount);
+    } catch (e) {
+        console.warn(`tabs.setScrollState: No tabs with id ${id} found.`);
+
+        return false;
+    }
+
+    return tab;
+};
+
 export default {
-    init
+    init,
+    setScrollState
 };


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Some tools, such as React, does not work well with how the scroll of the scrollbar is currently handled (most likely due to rerendering on state changes thus resetting the tabs internal state). This is a proposed solution, which gives the user a way to control the scroll state of the tabs, making it possible to implement the intended behavior on different tools.  