### PR TITLE
Updated action link badge class name to badge-default

### DIFF
--- a/src/App/Documentation/components/ActionLink/__snapshots__/index.test.js.snap
+++ b/src/App/Documentation/components/ActionLink/__snapshots__/index.test.js.snap
@@ -19,7 +19,7 @@ exports[`Components: ActionLink ActionLinkBadge renders 1`] = `
       badge={
         Object {
           "text": "40",
-          "type": "badge-yellow",
+          "type": "badge-default",
         }
       }
       linkText="My link"
@@ -47,7 +47,7 @@ exports[`Components: ActionLink ActionLinkBadgeSmallText renders 1`] = `
       badge={
         Object {
           "text": "40",
-          "type": "badge-yellow",
+          "type": "badge-default",
         }
       }
       linkText="My link"
@@ -63,7 +63,7 @@ exports[`Components: ActionLink ActionLinkBadgeSmallText renders 1`] = `
       badge={
         Object {
           "text": "40",
-          "type": "badge-yellow",
+          "type": "badge-default",
         }
       }
       linkText="My link"

--- a/src/App/Documentation/components/ActionLink/index.js
+++ b/src/App/Documentation/components/ActionLink/index.js
@@ -14,7 +14,7 @@ const Overview = () => (
 );
 
 const badge = {
-    type: "badge-yellow",
+    type: "badge-default",
     text: "40"
 };
 

--- a/src/App/components/ActionLink/__snapshots__/index.test.js.snap
+++ b/src/App/components/ActionLink/__snapshots__/index.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Component: ActionLink ActionLinkContent renders ActionLinkContent with badge if badge is provided 1`] = `
 <Fragment>
   <span
-    className="badge badge-yellow"
+    className="badge badge-default"
   >
     Badge
   </span>

--- a/src/App/components/ActionLink/index.test.js
+++ b/src/App/components/ActionLink/index.test.js
@@ -45,20 +45,20 @@ describe("Component: ActionLink", () => {
 
         it("renders ActionLinkContent with badge if badge is provided", () => {
             const mockBadge = {
-                type: "badge-yellow",
+                type: "badge-default",
                 text: "Badge"
             };
             const wrapper = shallow(<ActionLinkContent linkText="Link text" badge={mockBadge} />);
 
             expect(wrapper).toMatchSnapshot();
-            expect(wrapper.contains(<span className="badge badge-yellow" >Badge</span>)).toEqual(true);
+            expect(wrapper.contains(<span className="badge badge-default" >Badge</span>)).toEqual(true);
         });
 
         it("renders ActionLinkContent without badge if badge is not provided", () => {
             const wrapper = shallow(<ActionLinkContent linkText="Link text" />);
 
             expect(wrapper).toMatchSnapshot();
-            expect(wrapper.contains(<span className="badge badge-yellow" >Badge</span>)).toEqual(false);
+            expect(wrapper.contains(<span className="badge badge-default" >Badge</span>)).toEqual(false);
         });
 
         it("renders ActionLinkContent with smalltext when provided", () => {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Action Link used an old class name (badge yellow). This is now fixed
