### PR TITLE
Reintroduce babel/polyfill

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,6 +1,6 @@
 {
     "presets": [
-        ["@babel/preset-env", { "useBuiltIns": "usage", "corejs": 3 }],
+        "@babel/preset-env",
         "@babel/preset-react"
     ],
     "plugins": [
@@ -34,7 +34,7 @@
     "env": {
         "test": {
             "presets": [
-                ["@babel/preset-env", { "useBuiltIns": "usage", "corejs": 3 }],
+                "@babel/preset-env",
                 "@babel/preset-react"
             ],
             "plugins": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1019,20 +1019,18 @@
             }
         },
         "@babel/polyfill": {
-            "version": "7.4.4",
-            "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.4.4.tgz",
-            "integrity": "sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==",
-            "dev": true,
+            "version": "7.7.0",
+            "resolved": "https://registry.npmjs.org/@babel/polyfill/-/polyfill-7.7.0.tgz",
+            "integrity": "sha512-/TS23MVvo34dFmf8mwCisCbWGrfhbiWZSwBo6HkADTBhUa2Q/jWltyY/tpofz/b6/RIhqaqQcquptCirqIhOaQ==",
             "requires": {
                 "core-js": "^2.6.5",
                 "regenerator-runtime": "^0.13.2"
             },
             "dependencies": {
                 "core-js": {
-                    "version": "2.6.10",
-                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.10.tgz",
-                    "integrity": "sha512-I39t74+4t+zau64EN1fE5v2W31Adtc/REhzWN+gWRRXg6WH5qAsZm62DHpQ1+Yhe4047T55jvzz7MUqF/dBBlA==",
-                    "dev": true
+                    "version": "2.6.11",
+                    "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.11.tgz",
+                    "integrity": "sha512-5wjnpaT/3dV+XB4borEsnAYQchn00XSgTAWKDkEqv+K8KevjbzmofK6hfJ9TZIlpj2N0xQpazy7PiRQiWHqzWg=="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
         "ie >= 11"
     ],
     "dependencies": {
+        "@babel/polyfill": "^7.7.0",
         "chart.js": "^2.8.0",
         "classnames": "^2.2.6",
         "core-js": "^3.4.5",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -27,9 +27,9 @@ module.exports = (env, argv) => {
 
     const config = {
         entry: {
-            dg: ["./src/scripts/main/index.js"],
+            dg: ["@babel/polyfill", "./src/scripts/main/index.js"],
             "dg-dashboard": "./src/scripts/dashboard/index.js",
-            app: [`./src/${brand}.js`]
+            app: ["@babel/polyfill/noConflict", `./src/${brand}.js`]
         },
         resolve: {
             extensions: [".js", ".jsx", ".json"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Reintroduced @babel/polyfill as moving to core-js@3 broke the compatibility with Internet Explorer. Changing to core-js@3 will be implemented again later, as @babel/polyfill is deprecated. This is just a temporarily fix.

Temporarily fixes [DG-444](https://payexjira.atlassian.net/secure/RapidBoard.jspa?rapidView=80&projectKey=DG&modal=detail&selectedIssue=DG-444)
