### PR TITLE
Fix pull request builds

### DIFF
--- a/build/appveyor.yml
+++ b/build/appveyor.yml
@@ -33,7 +33,11 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version x64
   - cmd: >-
-      choco install gitversion.portable
+      git fetch --unshallow
+      git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
+      git fetch origin
+
+      choco install gitversion.portable -y
 
       gitversion /l console /output buildserver
 

--- a/build/appveyor.yml
+++ b/build/appveyor.yml
@@ -50,18 +50,18 @@ install:
 before_build:
   - ps: ./build/prepare-build.ps1
 
-# build_script:
-  # - cmd: npm run build:prod -- --env.release=%release% --env.basename=%basename% --env.semver=%GitVersion_FullSemVer% --env.info_version=%GitVersion_InformationalVersion%
+build_script:
+  - cmd: npm run build:prod -- --env.release=%release% --env.basename=%basename% --env.semver=%GitVersion_FullSemVer% --env.info_version=%GitVersion_InformationalVersion%
 
 #---------------------------------#
 #       tests configuration       #
 #---------------------------------#
 
-# test_script:
-#   - cmd: >-
-#       npm run lint
+test_script:
+  - cmd: >-
+      npm run lint
 
-#       npm run test:codecov
+      npm run test:codecov
 
 #---------------------------------#
 #     deployment configuration    #

--- a/build/appveyor.yml
+++ b/build/appveyor.yml
@@ -33,7 +33,7 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version x64
   - cmd: >-
-      choco install gitversion.portable -pre -y
+      choco install gitversion.portable
 
       gitversion /l console /output buildserver
 

--- a/build/appveyor.yml
+++ b/build/appveyor.yml
@@ -38,9 +38,9 @@ install:
 
       gitversion /l console /output buildserver
 
-      npm ci
+      # npm ci
 
-      npm install -g codecov
+      # npm install -g codecov
 
 
 #---------------------------------#
@@ -50,18 +50,18 @@ install:
 before_build:
   - ps: ./build/prepare-build.ps1
 
-build_script:
-  - cmd: npm run build:prod -- --env.release=%release% --env.basename=%basename% --env.semver=%GitVersion_FullSemVer% --env.info_version=%GitVersion_InformationalVersion%
+# build_script:
+  # - cmd: npm run build:prod -- --env.release=%release% --env.basename=%basename% --env.semver=%GitVersion_FullSemVer% --env.info_version=%GitVersion_InformationalVersion%
 
 #---------------------------------#
 #       tests configuration       #
 #---------------------------------#
 
-test_script:
-  - cmd: >-
-      npm run lint
+# test_script:
+#   - cmd: >-
+#       npm run lint
 
-      npm run test:codecov
+#       npm run test:codecov
 
 #---------------------------------#
 #     deployment configuration    #

--- a/build/appveyor.yml
+++ b/build/appveyor.yml
@@ -38,9 +38,9 @@ install:
 
       gitversion /l console /output buildserver
 
-      # npm ci
+      npm ci
 
-      # npm install -g codecov
+      npm install -g codecov
 
 
 #---------------------------------#

--- a/build/appveyor.yml
+++ b/build/appveyor.yml
@@ -33,9 +33,6 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version x64
   - cmd: >-
-      git fetch --unshallow
-      git config remote.origin.fetch "+refs/heads/*:refs/remotes/origin/*"
-      git fetch origin
 
       choco install gitversion.portable -y
 

--- a/build/prepare-deploy.ps1
+++ b/build/prepare-deploy.ps1
@@ -1,4 +1,4 @@
-Write-Host "Pull request number?" $Env:APPVEYOR_PULL_REQUEST_NUMBER
+Write-Host "Pull request number: $Env:APPVEYOR_PULL_REQUEST_NUMBER"
 
 # Avoid deploying PR's as they do not have access to secrets
 if ($null -eq $Env:APPVEYOR_PULL_REQUEST_NUMBER -And $Env:GitVersion_PreReleaseLabel -NotMatch "dependabot") {

--- a/build/prepare-deploy.ps1
+++ b/build/prepare-deploy.ps1
@@ -1,13 +1,7 @@
-Write-Host $Env:GitVersion_PreReleaseLabel
-
-if($Env:APPVEYOR_PULL_REQUEST_NUMBER) {
-    Write-Host "This is a pull request"
-} else {
-    Write-Host "This is NOT a pull request"
-}
+Write-Host "Pull request number?" $Env:APPVEYOR_PULL_REQUEST_NUMBER
 
 # Avoid deploying PR's as they do not have access to secrets
-if ($Env:GitVersion_PreReleaseLabel -NotMatch "PullRequest" -And $Env:GitVersion_PreReleaseLabel -NotMatch "dependabot") {
+if ($null -eq $Env:APPVEYOR_PULL_REQUEST_NUMBER -And $Env:GitVersion_PreReleaseLabel -NotMatch "dependabot") {
     # Deploy to github pages
     ./build/deploy-github-pages.ps1
 

--- a/build/prepare-deploy.ps1
+++ b/build/prepare-deploy.ps1
@@ -1,3 +1,5 @@
+Write-Host $Env:GitVersion_PreReleaseLabel
+
 # Avoid deploying PR's as they do not have access to secrets
 if ($Env:GitVersion_PreReleaseLabel -NotMatch "PullRequest" -And $Env:GitVersion_PreReleaseLabel -NotMatch "dependabot") {
     # Deploy to github pages

--- a/build/prepare-deploy.ps1
+++ b/build/prepare-deploy.ps1
@@ -1,5 +1,11 @@
 Write-Host $Env:GitVersion_PreReleaseLabel
 
+if($Env:APPVEYOR_PULL_REQUEST_NUMBER) {
+    Write-Host "This is a pull request"
+} else {
+    Write-Host "This is NOT a pull request"
+}
+
 # Avoid deploying PR's as they do not have access to secrets
 if ($Env:GitVersion_PreReleaseLabel -NotMatch "PullRequest" -And $Env:GitVersion_PreReleaseLabel -NotMatch "dependabot") {
     # Deploy to github pages


### PR DESCRIPTION
- Use LTS version of GitVersion.
- Updates pull request check when deciding whether to deploy to gh-pages or not.
  - This could be done through GitVersion but seeing as we're phasing AppVeyor out ATM, I'm not too keen to spend too much time on it. It works now!