### PR TITLE
Fix action-list background color, sidebar nav-leaf alignment

### DIFF
--- a/src/less/components/action-list.less
+++ b/src/less/components/action-list.less
@@ -43,7 +43,7 @@
         line-height: 1.1;
         user-select: none;
         border-radius: 2px;
-        background-color: inherit;
+        background-color: transparent;
         color: @brand-secondary-dark-2;
         display: flex;
         padding: 0;

--- a/src/less/components/sidebar.less
+++ b/src/less/components/sidebar.less
@@ -149,6 +149,7 @@
                             height: 100%;
                             width: 0.125rem;
                             left: 0;
+                            top: 0;
                             background-color: @brand-bg-gray;
                         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes two issues with styling on IE11:

1. Action list toggle button seems to inherit the default button color.
2. Sidebar nav-leaf is not properly aligned

## Motivation and Context
These issues result in the components not fitting in or look non-professional 

## How Has This Been Tested?
Tested manually on different browsers.

## Screenshots (if appropriate):
Action list toggle button seems to inherit the default button color:
![image](https://user-images.githubusercontent.com/11156181/74340773-da43ae80-4da6-11ea-94a0-001fc9fb06d3.png)
 

Sidebar nav-leaf not properly aligned:
![image](https://user-images.githubusercontent.com/11156181/74340636-918bf580-4da6-11ea-8855-90c2003f6d30.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
