### PR TITLE
Add missing imports for payex

### DIFF
--- a/src/less/_variables-payex.less
+++ b/src/less/_variables-payex.less
@@ -49,6 +49,7 @@
 /* Brand fonts */
 @brand-headline:                            "Roboto", sans-serif;
 @brand-default:                             "Roboto", sans-serif;
+@brand-monofont:                            monospace;
 
 /* Button colors */
 @executive-disabled-bg:                     #f5b895;

--- a/src/less/payex.less
+++ b/src/less/payex.less
@@ -31,6 +31,7 @@
 @import "components/breadcrumb";
 @import "components/button";
 @import "components/card";
+@import "components/code-tags";
 @import "components/datepicker";
 @import "components/dialog";
 @import "components/expandable";
@@ -44,6 +45,7 @@
 @import "components/pagination";
 @import "components/panel";
 @import "components/sheet";
+@import "components/sidebar";
 @import "components/slab";
 @import "components/status";
 @import "components/steps";
@@ -53,3 +55,6 @@
 @import "components/tooltip";
 @import "components/topbar";
 @import "components/validation";
+
+/* Examples */
+@import "examples/sidebar";


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
PayEx version of Design guide is missing some imports of .less files, causing some weird styling on some components. Added the missing imports to fix these issues. 