### PR TITLE
Exclude chunks when comparing compression sizes

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -40,4 +40,5 @@ jobs:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
           # basename=PullRequest is added to avoid BundleAnalyzer from holding up the agent [THN]
           build-script: "${{ steps.variables.outputs.BRAND_BUILD_SCRIPT }} -- --env.basename=PullRequest"
+          exclude: "{**/*.map,**/node_modules/**,**/*chunk*.*}"
           pattern: "{dist/**/*.js,dist/**/*.css}"


### PR DESCRIPTION
We're not too interested in chunks as they are documentation only scripts.
![image](https://user-images.githubusercontent.com/26485094/76204970-ac148b80-61f9-11ea-8dcb-07edc7632cd6.png)

Let's focus solely on the main Design Guide scripts and styles that consumers will use instead.

Which will end up like this:
![image](https://user-images.githubusercontent.com/26485094/76205679-0235fe80-61fb-11ea-9b83-031191efbb60.png)
