### PR TITLE
Fix sheet scroll bug

### DIFF
--- a/src/scripts/main/sheet/index.js
+++ b/src/scripts/main/sheet/index.js
@@ -42,9 +42,9 @@ class Sheet {
 
         // Remove classes that prevent scrolling if user navigates away from page without closing a sheet
         window.addEventListener("popstate", () => {
-            if (document.body.classList.value && document.body.classList.value.includes("sheet-open")) { document.body.classList.remove("sheet-open"); }
+            if (document.body.className.includes("sheet-open")) { document.body.classList.remove("sheet-open"); }
 
-            if (document.body.classList.value && document.body.classList.value.includes("has-vscroll")) { document.body.classList.remove("has-vscroll"); }
+            if (document.body.className.includes("has-vscroll")) { document.body.classList.remove("has-vscroll"); }
         });
 
         this._initializeButtons();

--- a/src/scripts/main/sheet/index.js
+++ b/src/scripts/main/sheet/index.js
@@ -40,6 +40,14 @@ class Sheet {
             });
         }
 
+        // Remove classes that prevent scrolling if user navigates away from page without closing a sheet
+        window.addEventListener("popstate", () => {
+            const bodyElement = document.querySelector("body");
+
+            bodyElement.classList.value.includes("sheet-open") ? bodyElement.classList.remove("sheet-open") : null;
+            bodyElement.classList.value.includes("has-vscroll") ? bodyElement.classList.remove("has-vscroll") : null;
+        });
+
         this._initializeButtons();
     }
 

--- a/src/scripts/main/sheet/index.js
+++ b/src/scripts/main/sheet/index.js
@@ -42,10 +42,9 @@ class Sheet {
 
         // Remove classes that prevent scrolling if user navigates away from page without closing a sheet
         window.addEventListener("popstate", () => {
-            const bodyElement = document.querySelector("body");
+            if (document.body.classList.value && document.body.classList.value.includes("sheet-open")) { document.body.classList.remove("sheet-open"); }
 
-            bodyElement.classList.value.includes("sheet-open") ? bodyElement.classList.remove("sheet-open") : null;
-            bodyElement.classList.value.includes("has-vscroll") ? bodyElement.classList.remove("has-vscroll") : null;
+            if (document.body.classList.value && document.body.classList.value.includes("has-vscroll")) { document.body.classList.remove("has-vscroll"); }
         });
 
         this._initializeButtons();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Adds an event listener to window on sheet init that removes classes from body that would otherwise disable scrolling.

Should fix [issue 291](https://github.com/SwedbankPay/design.swedbankpay.com/issues/291)

Haven't tested it thoroughly on all browsers etc at the time of writing
