### PR TITLE
Adjust vertical link before element

### DIFF
--- a/src/less/components/progress-steps.less
+++ b/src/less/components/progress-steps.less
@@ -267,6 +267,12 @@
                 padding: @list-item-padding-desktop-vertical;
                 width: auto;
                 .negative-margin(@list-item-padding-desktop-vertical);
+
+                &:before {
+                    margin-left: 0;
+                    left: @vertical-left;
+                    top: 50%;
+                }
             }
 
             /* Circle */


### PR DESCRIPTION
Quickfix for [338](https://github.com/SwedbankPay/design.swedbankpay.com/issues/338)

![image](https://user-images.githubusercontent.com/26485094/83652265-b5c04c00-a5ba-11ea-9155-68b214fdad5d.png)
