### PR TITLE
Make datepicker time open immediately

### DIFF
--- a/src/App/ComponentsDocumentation/components/Datepickers/__snapshots__/index.test.js.snap
+++ b/src/App/ComponentsDocumentation/components/Datepickers/__snapshots__/index.test.js.snap
@@ -222,7 +222,6 @@ exports[`Documentation: Datepickers IncludeTime renders 1`] = `
       prefixType="icon"
       prefixValue="event"
       time={true}
-      value="28.12.1972 12:00"
     />
   </ComponentPreview>
 </Fragment>

--- a/src/App/ComponentsDocumentation/components/Datepickers/index.js
+++ b/src/App/ComponentsDocumentation/components/Datepickers/index.js
@@ -160,7 +160,6 @@ const IncludeTime = () => (
         </p>
         <ComponentPreview language="html" showCasePanel codeFigure>
             <DatepickerComponent
-                value="28.12.1972 12:00"
                 time
                 format="nb"
                 label="Date"

--- a/src/less/components/datepicker.less
+++ b/src/less/components/datepicker.less
@@ -5,6 +5,12 @@
         z-index: @zindex-datepicker;
     }
 
+    &.hasTime {
+        .flatpickr-time {
+            height: 40px;
+        }
+    }
+
     .flatpickr-weekday {
         color: @brand-secondary;
         font-size: @base-font-size;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Fixes [DG-558](https://payexjira.atlassian.net/secure/RapidBoard.jspa?rapidView=80&projectKey=DG&modal=detail&selectedIssue=DG-558)

This fixes an issue with time not being displayed immediately when default value is not set for datepicker with time component

## How Has This Been Tested?
Ran all existing tests

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
