### PR TITLE
Only deploy releases to gh-pages

### DIFF
--- a/build/deploy-github-pages.ps1
+++ b/build/deploy-github-pages.ps1
@@ -1,10 +1,8 @@
-if (($Env:APPVEYOR_REPO_TAG -eq "true") -and ($Env:GitVersion_BranchName -eq "master")) {
-    # Store content of CHANGELOG.md in env variable
-    $Env:changelog = [IO.File]::ReadAllText("C:\projects\design-swedbankpay-com\CHANGELOG.md")
+# Store content of CHANGELOG.md in env variable
+$Env:changelog = [IO.File]::ReadAllText("C:\projects\design-swedbankpay-com\CHANGELOG.md")
 
-    # Push artifact to appveyor
-    Push-AppveyorArtifact "dist/$Env:basename/release/SwedbankPay.DesignGuide.v$($Env:GitVersion_FullSemVer).zip"
-}
+# Push artifact to appveyor
+Push-AppveyorArtifact "dist/$Env:basename/release/SwedbankPay.DesignGuide.v$($Env:GitVersion_FullSemVer).zip"
 
 # Deploy to gh-pages
 Write-Host "Starting deploy to gh-pages"

--- a/build/prepare-deploy.ps1
+++ b/build/prepare-deploy.ps1
@@ -1,11 +1,12 @@
 Write-Host "Pull request number: $Env:APPVEYOR_PULL_REQUEST_NUMBER"
 
-# Avoid deploying PR's as they do not have access to secrets
-if ($null -eq $Env:APPVEYOR_PULL_REQUEST_NUMBER -And $Env:GitVersion_PreReleaseLabel -NotMatch "dependabot") {
+# Avoid deploying anything but a release.
+# Github Actions will deploy develop and feature branches to azure. [THN]
+if (($Env:APPVEYOR_REPO_TAG -eq "true") -and ($Env:GitVersion_BranchName -eq "master")) {
     # Deploy to github pages
     ./build/deploy-github-pages.ps1
 
     # TODO: Run functional tests etc here [EH]
 } else {
-    Write-Host "Pull request or dependabot branch, skipping deploy."
+    Write-Host "Not a release, skipping deploy."
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Only deploy tags/releases to gh-pages.

## Description
<!--- Describe your changes in detail -->
GitHub Actions deploys `develop` and all `feature/**` branches to stage servers. We no longer need to deploy anything except tags and releases to gh-pages (current production environment).

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
