### PR TITLE
Make brand title dynamic

### DIFF
--- a/src/App/ComponentsDocumentation/components/Components/__snapshots__/index.test.js.snap
+++ b/src/App/ComponentsDocumentation/components/Components/__snapshots__/index.test.js.snap
@@ -887,7 +887,7 @@ exports[`Components: Components renders 1`] = `
   <p
     className="lead"
   >
-    This is the Swedbank Pay component library. Here we’ve listed all the components in the Swedbank Pay design system. Feel free to look around!
+    This is our component library where we have listed all the components in our design system. Feel free to look around!
   </p>
   <MenuOverview />
 </DocContainer>

--- a/src/App/ComponentsDocumentation/components/Components/index.js
+++ b/src/App/ComponentsDocumentation/components/Components/index.js
@@ -22,7 +22,7 @@ const MenuOverview = () => (
 const Components = () => (
     <DocContainer>
         <p className="lead">
-        This is the Swedbank Pay component library. Here we’ve listed all the components in the Swedbank Pay design system. Feel free to look around!
+        This is our component library where we have listed all the components in our design system. Feel free to look around!
         </p>
         <MenuOverview />
     </DocContainer>

--- a/src/App/ComponentsDocumentation/components/Forms/__snapshots__/index.test.js.snap
+++ b/src/App/ComponentsDocumentation/components/Forms/__snapshots__/index.test.js.snap
@@ -676,7 +676,7 @@ exports[`Documentation: Forms StaticText renders 1`] = `
   >
     <FormControlText
       label="Company"
-      text="Swedbank Pay"
+      text="TESTBRAND"
     />
     <FormControlText
       label="Employee"

--- a/src/App/ComponentsDocumentation/components/Forms/index.js
+++ b/src/App/ComponentsDocumentation/components/Forms/index.js
@@ -237,7 +237,7 @@ const StaticText = () => (
         <h2 id="static-text">Static text</h2>
         <p>To just display static text in forms use a <CodeTags type="primary" code={"<span>"} /> inside a form</p>
         <ComponentPreview language="html" showCasePanel codeFigure>
-            <FormControlText label="Company" text="Swedbank Pay" />
+            <FormControlText label="Company" text={process.env.brandTitle} />
             <FormControlText label="Employee" text="Bob Corlsan" />
         </ComponentPreview>
     </>

--- a/src/App/ComponentsDocumentation/components/Lists/__snapshots__/index.test.js.snap
+++ b/src/App/ComponentsDocumentation/components/Lists/__snapshots__/index.test.js.snap
@@ -696,7 +696,9 @@ exports[`Documentation: Lists StripedItemList prevents default on anchors 1`] = 
         <a
           href="https://developer.payex.com"
         >
-          developer.swedbankpay.com
+          developer.
+          TESTBRAND
+          .com
         </a>
         
 
@@ -823,7 +825,9 @@ exports[`Documentation: Lists StripedItemList renders 1`] = `
         <a
           href="https://developer.payex.com"
         >
-          developer.swedbankpay.com
+          developer.
+          TESTBRAND
+          .com
         </a>
         
 

--- a/src/App/ComponentsDocumentation/components/Lists/index.js
+++ b/src/App/ComponentsDocumentation/components/Lists/index.js
@@ -303,7 +303,7 @@ const StripedItemList = () => (
                     <span>{"\n\t\t\t"}4925*********004{"\n\t\t\t"}
                         <span className="badge badge-blue">new</span>{"\n"}
                     </span>{"\n"}
-                    <a href="https://developer.payex.com">developer.swedbankpay.com</a>{"\n"}
+                    <a href="https://developer.payex.com">developer.{process.env.brand}.com</a>{"\n"}
                 </li>
                 <li>{"\n"}
                     <span>4925*********004</span>{"\n"}

--- a/src/App/ComponentsDocumentation/components/MediaObject/__snapshots__/index.test.js.snap
+++ b/src/App/ComponentsDocumentation/components/MediaObject/__snapshots__/index.test.js.snap
@@ -24,13 +24,13 @@ exports[`Documentation: MediaObject MediaPosition renders 1`] = `
       heading="Bob Corlsan"
       imgUrl="https://via.placeholder.com/48x48"
       mediaRight={true}
-      text="bob.corlsan@swedbankpay.com"
+      text="bob.corlsan@TESTBRAND.com"
     />
     <MediaObject
       heading="Bob Corlsan"
       icon="account_circle"
       mediaRight={true}
-      text="bob.corlsan@swedbankpay.com"
+      text="bob.corlsan@TESTBRAND.com"
     />
   </ComponentPreview>
 </Fragment>
@@ -59,12 +59,12 @@ exports[`Documentation: MediaObject Overview renders 1`] = `
     <MediaObject
       heading="Bob Corlsan"
       imgUrl="https://via.placeholder.com/48x48"
-      text="bob.corlsan@swedbankpay.com"
+      text="bob.corlsan@TESTBRAND.com"
     />
     <MediaObject
       heading="Bob Corlsan"
       icon="account_circle"
-      text="bob.corlsan@swedbankpay.com"
+      text="bob.corlsan@TESTBRAND.com"
     />
   </ComponentPreview>
 </Fragment>
@@ -102,13 +102,13 @@ exports[`Documentation: MediaObject Sizes renders 1`] = `
       heading="Bob Corlsan"
       imgUrl="https://via.placeholder.com/40x40"
       size="sm"
-      text="bob.corlsan@swedbankpay.com"
+      text="bob.corlsan@TESTBRAND.com"
     />
     <MediaObject
       heading="Bob Corlsan"
       icon="account_circle"
       size="sm"
-      text="bob.corlsan@swedbankpay.com"
+      text="bob.corlsan@TESTBRAND.com"
     />
   </ComponentPreview>
   <h3>
@@ -123,13 +123,13 @@ exports[`Documentation: MediaObject Sizes renders 1`] = `
       heading="Bob Corlsan"
       imgUrl="https://via.placeholder.com/56x56"
       size="lg"
-      text="bob.corlsan@swedbankpay.com"
+      text="bob.corlsan@TESTBRAND.com"
     />
     <MediaObject
       heading="Bob Corlsan"
       icon="account_circle"
       size="lg"
-      text="bob.corlsan@swedbankpay.com"
+      text="bob.corlsan@TESTBRAND.com"
     />
   </ComponentPreview>
 </Fragment>

--- a/src/App/ComponentsDocumentation/components/MediaObject/index.js
+++ b/src/App/ComponentsDocumentation/components/MediaObject/index.js
@@ -4,13 +4,15 @@ import { ComponentPreview, DocContainer } from "@docutils";
 import MediaObjectComponent from "@components/MediaObject";
 import CodeTags from "@components/CodeTags";
 
+const brand = process.env.brand;
+
 const Overview = () => (
     <>
         <h2 id="overview">Overview</h2>
         <p>Use the <CodeTags type="secondary" code=".media" /> class on an object to style it as a small container that feature a left- or right-aligned image/icon alongside textual content.</p>
         <ComponentPreview language="html" showCasePanel codeFigure>
-            <MediaObjectComponent imgUrl="https://via.placeholder.com/48x48" heading="Bob Corlsan" text="bob.corlsan@swedbankpay.com" />
-            <MediaObjectComponent icon="account_circle" heading="Bob Corlsan" text="bob.corlsan@swedbankpay.com" />
+            <MediaObjectComponent imgUrl="https://via.placeholder.com/48x48" heading="Bob Corlsan" text={`bob.corlsan@${brand}.com`} />
+            <MediaObjectComponent icon="account_circle" heading="Bob Corlsan" text={`bob.corlsan@${brand}.com`} />
         </ComponentPreview>
     </>
 );
@@ -23,13 +25,13 @@ const Sizes = () => (
         </p>
         <h3>Small</h3>
         <ComponentPreview language="html" showCasePanel codeFigure>
-            <MediaObjectComponent size="sm" imgUrl="https://via.placeholder.com/40x40" heading="Bob Corlsan" text="bob.corlsan@swedbankpay.com" />
-            <MediaObjectComponent size="sm" icon="account_circle" heading="Bob Corlsan" text="bob.corlsan@swedbankpay.com" />
+            <MediaObjectComponent size="sm" imgUrl="https://via.placeholder.com/40x40" heading="Bob Corlsan" text={`bob.corlsan@${brand}.com`} />
+            <MediaObjectComponent size="sm" icon="account_circle" heading="Bob Corlsan" text={`bob.corlsan@${brand}.com`} />
         </ComponentPreview>
         <h3>Large</h3>
         <ComponentPreview language="html" showCasePanel codeFigure>
-            <MediaObjectComponent size="lg" imgUrl="https://via.placeholder.com/56x56" heading="Bob Corlsan" text="bob.corlsan@swedbankpay.com" />
-            <MediaObjectComponent size="lg" icon="account_circle" heading="Bob Corlsan" text="bob.corlsan@swedbankpay.com" />
+            <MediaObjectComponent size="lg" imgUrl="https://via.placeholder.com/56x56" heading="Bob Corlsan" text={`bob.corlsan@${brand}.com`} />
+            <MediaObjectComponent size="lg" icon="account_circle" heading="Bob Corlsan" text={`bob.corlsan@${brand}.com`} />
         </ComponentPreview>
     </>
 );
@@ -39,8 +41,8 @@ const MediaPosition = () => (
         <h2 id="media-position">Media position</h2>
         <p>Use the <CodeTags type="secondary" code=".media-right" /> class to align the media content to the right.</p>
         <ComponentPreview language="html" showCasePanel codeFigure>
-            <MediaObjectComponent mediaRight imgUrl="https://via.placeholder.com/48x48" heading="Bob Corlsan" text="bob.corlsan@swedbankpay.com" />
-            <MediaObjectComponent mediaRight icon="account_circle" heading="Bob Corlsan" text="bob.corlsan@swedbankpay.com" />
+            <MediaObjectComponent mediaRight imgUrl="https://via.placeholder.com/48x48" heading="Bob Corlsan" text={`bob.corlsan@${brand}.com`} />
+            <MediaObjectComponent mediaRight icon="account_circle" heading="Bob Corlsan" text={`bob.corlsan@${brand}.com`} />
         </ComponentPreview>
     </>
 );

--- a/src/App/ComponentsDocumentation/components/Topbar/__snapshots__/index.test.js.snap
+++ b/src/App/ComponentsDocumentation/components/Topbar/__snapshots__/index.test.js.snap
@@ -43,7 +43,9 @@ exports[`Components: Topbar Overview renders 1`] = `
     </li>
   </ul>
   <p>
-    With this you get a topbar with the Swedbank Pay logo. In the topbar you can add additional functionality like a menu containing links. To enable this add a 
+    With this you get a topbar with the 
+    TESTBRAND
+     logo. In the topbar you can add additional functionality like a menu containing links. To enable this add a 
     <CodeTags
       code="<button>"
       type="primary"

--- a/src/App/ComponentsDocumentation/components/Topbar/index.js
+++ b/src/App/ComponentsDocumentation/components/Topbar/index.js
@@ -41,7 +41,7 @@ const Overview = () => (
             <li>Anchor with class <CodeTags type="secondary" code=".topbar-logo" /> to display the logo and make it clickable.</li>
         </ul>
         <p>
-            With this you get a topbar with the Swedbank Pay logo.
+            With this you get a topbar with the {process.env.brandTitle} logo.
             In the topbar you can add additional functionality like a menu containing links. To enable this add a <CodeTags type="primary" code={"<button>"} /> and
             a <CodeTags type="primary" code={"<nav>"} /> containing anchors. Remember to include <CodeTags type="secondary" code={"toggle-nav=\"{your_nav_id}\""} /> as
             a <CodeTags type="primary" code={"<button>"} /> attribute

--- a/src/App/GettingStarted/getting-started/ForDesigners/__snapshots__/index.test.js.snap
+++ b/src/App/GettingStarted/getting-started/ForDesigners/__snapshots__/index.test.js.snap
@@ -131,13 +131,17 @@ exports[`GettingStarted: ForDesigners NeedToHave renders 1`] = `
     What you need to have
   </h2>
   <p>
-    Here are some things you need to have access to in order to get up to speed – our Figma project and the Swedbank Pay fonts.
+    Here are some things you need to have access to in order to get up to speed – our Figma project and the 
+    TESTBRAND
+     fonts.
   </p>
   <h3>
     Design tools
   </h3>
   <p>
-    At Swedbank Pay Design we use Figma for all our design needs, it is an online design and prototyping tool but we recommend that you download the application for the full experience. Everything you need to know about how we work in Figma is documented in our project and can be accessed through the Onboarding file. Please contact one of our design guide team members if you need any help.
+    At 
+    TESTBRAND
+     Design we use Figma for all our design needs, it is an online design and prototyping tool but we recommend that you download the application for the full experience. Everything you need to know about how we work in Figma is documented in our project and can be accessed through the Onboarding file. Please contact one of our design guide team members if you need any help.
   </p>
   <p>
     If you need access to the project contact you manager or write in the Slack channel 
@@ -204,7 +208,9 @@ exports[`GettingStarted: ForDesigners NeedToKnow renders 1`] = `
     What you need to know
   </h2>
   <p>
-    When you have the right tools to get started there are some things that define the Swedbank Pay Design that are good to be familiar with. We try our best to always design with our brand and identity in the back of our heads. 
+    When you have the right tools to get started there are some things that define the 
+    TESTBRAND
+     Design that are good to be familiar with. We try our best to always design with our brand and identity in the back of our heads. 
   </p>
   <h3>
     Brand and identity
@@ -218,24 +224,6 @@ exports[`GettingStarted: ForDesigners NeedToKnow renders 1`] = `
     </Link>
     . 
   </p>
-  <a
-    className="icon-link"
-    href="https://brand-manager.swedbank.com/start/guidelines/swedbank-pay.html"
-    rel="noopener noreferrer"
-    target="_blank"
-  >
-    <i
-      aria-hidden="true"
-      className="material-icons"
-    >
-      launch
-    </i>
-    <span
-      className="ml-2"
-    >
-      Read more about the Swedbank Pay Brand (Swedbank Brand Manager) 
-    </span>
-  </a>
   <h3>
     Grid and breakpoints
   </h3>
@@ -268,7 +256,9 @@ exports[`GettingStarted: ForDesigners renders 1`] = `
   <p
     className="lead mb-5"
   >
-    We are thrilled to have you onboard in the Swedbank Pay Design team. In order to get started designing with us we have prepared a get started guide to help you understand the way our design system and this Design Guide works. Enjoy!
+    We are thrilled to have you onboard in the 
+    TESTBRAND
+     Design team. In order to get started designing with us we have prepared a get started guide to help you understand the way our design system and this Design Guide works. Enjoy!
   </p>
   <NeedToHave />
   <NeedToKnow />

--- a/src/App/GettingStarted/getting-started/ForDesigners/index.js
+++ b/src/App/GettingStarted/getting-started/ForDesigners/index.js
@@ -6,14 +6,15 @@ import Lightbox from "@components/Lightbox";
 import { DocContainer } from "@docutils";
 
 const basename = process.env.basename;
+const brandTitle = process.env.brandTitle;
 
 const NeedToHave = () => (
     <section>
         <h2 id="need-to-have">What you need to have</h2>
-        <p>Here are some things you need to have access to in order to get up to speed – our Figma project and the Swedbank Pay fonts.</p>
+        <p>Here are some things you need to have access to in order to get up to speed – our Figma project and the {brandTitle} fonts.</p>
 
         <h3>Design tools</h3>
-        <p>At Swedbank Pay Design we use Figma for all our design needs, it is an online design and prototyping tool but we recommend that you download the application for the full experience. Everything you need to know about how we work in Figma is documented in our project and can be accessed through the Onboarding file. Please contact one of our design guide team members if you need any help.</p>
+        <p>At {brandTitle} Design we use Figma for all our design needs, it is an online design and prototyping tool but we recommend that you download the application for the full experience. Everything you need to know about how we work in Figma is documented in our project and can be accessed through the Onboarding file. Please contact one of our design guide team members if you need any help.</p>
         <p>If you need access to the project contact you manager or write in the Slack channel <strong>#design-guide-general.</strong></p>
         <a href="https://www.figma.com/downloads/" className="icon-link d-block" target="_blank" rel="noopener noreferrer">
             <i className="material-icons" aria-hidden="true">launch</i>
@@ -31,14 +32,14 @@ const NeedToHave = () => (
 const NeedToKnow = () => (
     <section>
         <h2 id="need-to-know">What you need to know</h2>
-        <p>When you have the right tools to get started there are some things that define the Swedbank Pay Design that are good to be familiar with. We try our best to always design with our brand and identity in the back of our heads. </p>
+        <p>When you have the right tools to get started there are some things that define the {brandTitle} Design that are good to be familiar with. We try our best to always design with our brand and identity in the back of our heads. </p>
 
         <h3>Brand and identity</h3>
         <p>Open, simple and caring. These are our values that we always strive to come back to when we design both internal and external experiences. All information about our core values and things that make us who we are can be found in <Link to="/identity/identity">Identity</Link>. </p>
-        <a href="https://brand-manager.swedbank.com/start/guidelines/swedbank-pay.html" className="icon-link" target="_blank" rel="noopener noreferrer">
+        {brandTitle === "Swedbank Pay" && <a href="https://brand-manager.swedbank.com/start/guidelines/swedbank-pay.html" className="icon-link" target="_blank" rel="noopener noreferrer">
             <i className="material-icons" aria-hidden="true">launch</i>
             <span className="ml-2">Read more about the Swedbank Pay Brand (Swedbank Brand Manager) </span>
-        </a>
+        </a>}
 
         <h3>Grid and breakpoints</h3>
         <p>In order to align design and development as close as possible with each other we have pre-defined grids in Figma using the same size and breakpoints as in development. These grids are available in Figma and you can read more about how it is setup in the <Link to="/identity/grid">Grid section</Link>.</p>
@@ -88,7 +89,7 @@ const DiscoverMore = () => (
 
 const ForDevelopers = () => (
     <DocContainer>
-        <p className="lead mb-5">We are thrilled to have you onboard in the Swedbank Pay Design team. In order to get started designing with us we have prepared a get started guide to help you understand the way our design system and this Design Guide works. Enjoy!</p>
+        <p className="lead mb-5">We are thrilled to have you onboard in the {brandTitle} Design team. In order to get started designing with us we have prepared a get started guide to help you understand the way our design system and this Design Guide works. Enjoy!</p>
         <NeedToHave />
         <NeedToKnow />
         <Contributing />

--- a/src/App/GettingStarted/getting-started/ForDevelopers/__snapshots__/index.test.js.snap
+++ b/src/App/GettingStarted/getting-started/ForDevelopers/__snapshots__/index.test.js.snap
@@ -278,7 +278,9 @@ exports[`GettingStarted: ForDevelopers Installation renders 1`] = `
     Installation with CDN
   </h2>
   <p>
-    To quickly add the Swedbank Pay Design Guide to your project, include the snippets below in your project.
+    To quickly add the 
+    TESTBRAND
+     Design Guide to your project, include the snippets below in your project.
   </p>
   <h3>
     Include in the header
@@ -586,7 +588,9 @@ exports[`GettingStarted: ForDevelopers renders 1`] = `
   <p
     className="lead mb-5"
   >
-    To get you up and running with the Swedbank Pay Design Guide as quickly as possible, we have prepared this section showing you how to install it and what you will need to know in order to contribute to the project!
+    To get you up and running with the 
+    TESTBRAND
+     Design Guide as quickly as possible, we have prepared this section showing you how to install it and what you will need to know in order to contribute to the project!
   </p>
   <Installation />
   <GridAndBreakpoints />

--- a/src/App/GettingStarted/getting-started/ForDevelopers/index.js
+++ b/src/App/GettingStarted/getting-started/ForDevelopers/index.js
@@ -7,11 +7,12 @@ import CodeTags from "@components/CodeTags";
 
 const basename = process.env.basename;
 const brand = process.env.brand;
+const brandTitle = process.env.brandTitle;
 
 const Installation = () => (
     <section>
         <h2 id="installation">Installation with CDN</h2>
-        <p>To quickly add the Swedbank Pay Design Guide to your project, include the snippets below in your project.</p>
+        <p>To quickly add the {brandTitle} Design Guide to your project, include the snippets below in your project.</p>
         <h3>Include in the header</h3>
         <p>Copy-paste the following CSS code into <CodeTags type="secondary" code="<head>"/> before all the other stylesheets in order to load our CSS.</p>
         <ComponentPreview language="html" codeFigure>
@@ -145,7 +146,7 @@ const DiscoverMore = () => (
 
 const ForDevelopers = () => (
     <DocContainer>
-        <p className="lead mb-5">To get you up and running with the Swedbank Pay Design Guide as quickly as possible, we have prepared this section showing you how to install it and what you will need to know in order to contribute to the project!</p>
+        <p className="lead mb-5">To get you up and running with the {brandTitle} Design Guide as quickly as possible, we have prepared this section showing you how to install it and what you will need to know in order to contribute to the project!</p>
         <Installation/>
         <GridAndBreakpoints />
         <Contributing />

--- a/src/App/GettingStarted/getting-started/Introduction/__snapshots__/index.test.js.snap
+++ b/src/App/GettingStarted/getting-started/Introduction/__snapshots__/index.test.js.snap
@@ -61,7 +61,9 @@ exports[`GettingStarted: Introduction GetStarted renders 1`] = `
           For designers
         </span>
         <span>
-          Get ready to use the Design Guide when designing in Swedbank Pay.
+          Get ready to use the Design Guide when designing in 
+          TESTBRAND
+          .
         </span>
       </div>
       <i
@@ -121,148 +123,6 @@ exports[`GettingStarted: Introduction UsingDG renders 1`] = `
   <p>
     By doing so, when an adjustment or change occurs with one of the Design Guide components, all the projects which uses the said component will have the changes applied to their product automatically. This way the Design Guide enables a cohesive and unified design across the organization which saves time for everyone involved.  
   </p>
-  <h3>
-    Products using the Design Guide
-  </h3>
-  <p>
-    Because there’s a difference of following the design guidelines and using the Design Guide, not all Swedbank Pay products per definition uses the Design Guide. 
-  </p>
-  <table
-    className="table table-plain"
-  >
-    <thead>
-      <tr>
-        <th>
-          Product
-        </th>
-        <th>
-          Using Design Guide
-        </th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr
-        key="Checkout"
-      >
-        <td>
-          Checkout
-        </td>
-        <td>
-          <i
-            className="material-icons mr-3"
-          >
-            close
-          </i>
-          No, but are following the Design Guide
-        </td>
-      </tr>
-      <tr
-        key="Swedbankpay.se"
-      >
-        <td>
-          Swedbankpay.se
-        </td>
-        <td>
-          <i
-            className="material-icons mr-3"
-          >
-            close
-          </i>
-          No
-        </td>
-      </tr>
-      <tr
-        key="Consumer Portal"
-      >
-        <td>
-          Consumer Portal
-        </td>
-        <td>
-          <i
-            className="material-icons mr-3"
-          >
-            check
-          </i>
-          Yes
-        </td>
-      </tr>
-      <tr
-        key="Developer Portal"
-      >
-        <td>
-          Developer Portal
-        </td>
-        <td>
-          <i
-            className="material-icons mr-3"
-          >
-            check
-          </i>
-          Yes
-        </td>
-      </tr>
-      <tr
-        key="Card terminals"
-      >
-        <td>
-          Card terminals
-        </td>
-        <td>
-          <i
-            className="material-icons mr-3"
-          >
-            close
-          </i>
-          No, but are following the Design Guide
-        </td>
-      </tr>
-      <tr
-        key="Ecom Merchant Admin"
-      >
-        <td>
-          Ecom Merchant Admin
-        </td>
-        <td>
-          <i
-            className="material-icons mr-3"
-          >
-            check
-          </i>
-          Yes
-        </td>
-      </tr>
-      <tr
-        key="Ecom Owner Admin"
-      >
-        <td>
-          Ecom Owner Admin
-        </td>
-        <td>
-          <i
-            className="material-icons mr-3"
-          >
-            check
-          </i>
-          Yes
-        </td>
-      </tr>
-      <tr
-        key="Onboarding Signup"
-      >
-        <td>
-          Onboarding Signup
-        </td>
-        <td>
-          <i
-            className="material-icons mr-3"
-          >
-            check
-          </i>
-          Yes, is currently implemented the Design Guide
-        </td>
-      </tr>
-    </tbody>
-  </table>
 </section>
 `;
 
@@ -274,10 +134,14 @@ exports[`GettingStarted: Introduction WhatIsDG renders 1`] = `
     What is the Design Guide?
   </h2>
   <p>
-    The Swedbank Pay design system consists of two parts; the Figma designs and the web Design Guide (where you are right now). The Design Guide is the ready-to-use part of the design system and the Figma design library is for designing and prototyping.
+    The 
+    TESTBRAND
+     design system consists of two parts; the Figma designs and the web Design Guide (where you are right now). The Design Guide is the ready-to-use part of the design system and the Figma design library is for designing and prototyping.
   </p>
   <p>
-    The Design Guide consists of more than design. It contains all the parts of the design system that actually can be used and implemented by developers working with Swedbank Pay products.
+    The Design Guide consists of more than design. It contains all the parts of the design system that actually can be used and implemented by developers working with 
+    TESTBRAND
+     products.
   </p>
   <blockquote
     className="blockquote"
@@ -294,11 +158,12 @@ exports[`GettingStarted: Introduction renders 1`] = `
   <p
     className="lead"
   >
-    We are so glad to see that you are interested in learning more about the Swedbank Pay Design Guide. We know that it can be daunting to start with something new and complex. But don’t worry, we have got what you need!
+    We are so glad to see that you are interested in learning more about the 
+    TESTBRAND
+     Design Guide. We know that it can be daunting to start with something new and complex. But don’t worry, we have got what you need!
   </p>
   <GetStarted />
   <WhatIsDG />
   <UsingDG />
-  <OpenSimpleCaring />
 </DocContainer>
 `;

--- a/src/App/GettingStarted/getting-started/Introduction/index.js
+++ b/src/App/GettingStarted/getting-started/Introduction/index.js
@@ -5,6 +5,7 @@ import { designGuideUsers } from "./constants";
 import { DocContainer } from "@docutils";
 
 const basename = process.env.basename;
+const brandTitle = process.env.brandTitle;
 
 const GetStarted = () => (
     <section>
@@ -25,7 +26,7 @@ const GetStarted = () => (
                     <i className="material-icons">brush</i>
                 </div>
                 <div className="cards-content">
-                    <span className="h4">For designers</span><span>Get ready to use the Design Guide when designing in Swedbank Pay.</span>
+                    <span className="h4">For designers</span><span>Get ready to use the Design Guide when designing in {brandTitle}.</span>
                 </div>
                 <i className="material-icons">arrow_forward</i>
             </Link>
@@ -36,8 +37,8 @@ const GetStarted = () => (
 const WhatIsDG = () => (
     <section>
         <h2 id="what-is-dg">What is the Design Guide?</h2>
-        <p>The Swedbank Pay design system consists of two parts; the Figma designs and the web Design Guide (where you are right now). The Design Guide is the ready-to-use part of the design system and the Figma design library is for designing and prototyping.</p>
-        <p>The Design Guide consists of more than design. It contains all the parts of the design system that actually can be used and implemented by developers working with Swedbank Pay products.</p>
+        <p>The {brandTitle} design system consists of two parts; the Figma designs and the web Design Guide (where you are right now). The Design Guide is the ready-to-use part of the design system and the Figma design library is for designing and prototyping.</p>
+        <p>The Design Guide consists of more than design. It contains all the parts of the design system that actually can be used and implemented by developers working with {brandTitle} products.</p>
         <blockquote className="blockquote">
             <p>A design system is the single source of truth which groups all the elements that will allow the teams to design, realize and develop a product.</p>
         </blockquote>
@@ -52,24 +53,27 @@ const UsingDG = () => (
             <p>The Design Guide enables a cohesive and unified design across the organization which saves time for everyone involved. </p>
         </blockquote>
         <p>By doing so, when an adjustment or change occurs with one of the Design Guide components, all the projects which uses the said component will have the changes applied to their product automatically. This way the Design Guide enables a cohesive and unified design across the organization which saves time for everyone involved.  </p>
-        <h3>Products using the Design Guide</h3>
-        <p>Because there’s a difference of following the design guidelines and using the Design Guide, not all Swedbank Pay products per definition uses the Design Guide. </p>
-        <table className="table table-plain">
-            <thead>
-                <tr>
-                    <th>Product</th>
-                    <th>Using Design Guide</th>
-                </tr>
-            </thead>
-            <tbody>
-                {designGuideUsers.map(product => (
-                    <tr key={product.name}>
-                        <td>{product.name}</td>
-                        <td><i className="material-icons mr-3">{product.icon}</i>{product.text}</td>
+
+        {brandTitle === "Swedbank Pay" && <>
+            <h3>Products using the Design Guide</h3>
+            <p>Because there’s a difference of following the design guidelines and using the Design Guide, not all {brandTitle} products per definition uses the Design Guide. </p>
+            <table className="table table-plain">
+                <thead>
+                    <tr>
+                        <th>Product</th>
+                        <th>Using Design Guide</th>
                     </tr>
-                ))}
-            </tbody>
-        </table>
+                </thead>
+                <tbody>
+                    {designGuideUsers.map(product => (
+                        <tr key={product.name}>
+                            <td>{product.name}</td>
+                            <td><i className="material-icons mr-3">{product.icon}</i>{product.text}</td>
+                        </tr>
+                    ))}
+                </tbody>
+            </table>
+        </>}
     </section>
 );
 
@@ -84,11 +88,11 @@ const OpenSimpleCaring = () => (
 
 const Introduction = () => (
     <DocContainer>
-        <p className="lead">We are so glad to see that you are interested in learning more about the Swedbank Pay Design Guide. We know that it can be daunting to start with something new and complex. But don’t worry, we have got what you need!</p>
+        <p className="lead">We are so glad to see that you are interested in learning more about the {brandTitle} Design Guide. We know that it can be daunting to start with something new and complex. But don’t worry, we have got what you need!</p>
         <GetStarted />
         <WhatIsDG />
         <UsingDG />
-        <OpenSimpleCaring />
+        {brandTitle === "Swedbank Pay" && <OpenSimpleCaring />}
     </DocContainer>
 );
 

--- a/src/App/Identity/identity/Accessibility/__snapshots__/index.test.js.snap
+++ b/src/App/Identity/identity/Accessibility/__snapshots__/index.test.js.snap
@@ -124,25 +124,6 @@ exports[`Core: Accessibility DiveDeeper renders 1`] = `
   </h3>
   <a
     className="icon-link d-flex"
-    href="https://www.swedbank.com/sv/hallbarhet/ansvarsfulla-affarer/betala.html"
-    key="https://www.swedbank.com/sv/hallbarhet/ansvarsfulla-affarer/betala.html"
-    rel="noopener noreferrer"
-    target="_blank"
-  >
-    <i
-      aria-hidden="true"
-      className="material-icons mr-2"
-    >
-      open_in_new
-    </i>
-    <span
-      className="mr-2"
-    >
-      Swedbank – Ansvarsfulla affärer
-    </span>
-  </a>
-  <a
-    className="icon-link d-flex"
     href="https://polaris.shopify.com/foundations/accessibility"
     key="https://polaris.shopify.com/foundations/accessibility"
     rel="noopener noreferrer"
@@ -228,7 +209,9 @@ exports[`Core: Accessibility Inclusions renders 1`] = `
     Creating inclusion
   </h2>
   <p>
-    Today we’re working with awareness. All designers and developers at Swedbank Pay should be aware of accessibility, what it is, how it’s implemented and, what precautions we have to take to actually follow the law in the countries we’re in. As mentioned, accessibility may start with design but the main part is making our service compatible with accessibility helping tools, and that part happens in the technical implementation. 
+    Today we’re working with awareness. All designers and developers at 
+    TESTBRAND
+     should be aware of accessibility, what it is, how it’s implemented and, what precautions we have to take to actually follow the law in the countries we’re in. As mentioned, accessibility may start with design but the main part is making our service compatible with accessibility helping tools, and that part happens in the technical implementation. 
   </p>
   <p>
     Accessibility and WCAG can seem overwhelming and just as with everything else we need to take it step by step. This is a list from a Funka webinar held 2020-11-06:
@@ -260,7 +243,9 @@ exports[`Core: Accessibility Intro renders 1`] = `
   <p
     className="lead"
   >
-    At Swedbank Pay we value accessibility. Our products are meant to be used by people no matter of their abilities and therefor we strive to be WCAG (Web Content Accessibility Guidelines) compliant. We’re currently working on our accessibility awareness and meeting the terms of the  accessibility laws in Norway and Sweden. 
+    At 
+    TESTBRAND
+     we value accessibility. Our products are meant to be used by people no matter of their abilities and therefor we strive to be WCAG (Web Content Accessibility Guidelines) compliant. We’re currently working on our accessibility awareness and meeting the terms of the  accessibility laws in Norway and Sweden. 
   </p>
   <h2>
     What is accessibility
@@ -303,7 +288,9 @@ exports[`Core: Accessibility Intro renders 1`] = `
     </span>
   </div>
   <p>
-    At Swedbank Pay we strive to give all customers with disabilities and impairments (permanent, temporary and/or situational) a better chance of using our services on the same terms as others. 
+    At 
+    TESTBRAND
+     we strive to give all customers with disabilities and impairments (permanent, temporary and/or situational) a better chance of using our services on the same terms as others. 
   </p>
 </section>
 `;

--- a/src/App/Identity/identity/Accessibility/index.js
+++ b/src/App/Identity/identity/Accessibility/index.js
@@ -4,10 +4,13 @@ import * as externalLinks from "./constants";
 import { DocContainer } from "@docutils";
 
 const basename = process.env.basename;
+const brandTitle = process.env.brandTitle;
+
+const otherLinks = brandTitle === "Swedbank Pay" ? externalLinks.othersAboutAccessibility : externalLinks.othersAboutAccessibility.slice(1);
 
 const Intro = () => (
     <section>
-        <p className="lead">At Swedbank Pay we value accessibility. Our products are meant to be used by people no matter of their abilities and therefor we strive to be WCAG (Web Content Accessibility Guidelines) compliant. We’re currently working on our accessibility awareness and meeting the terms of the  accessibility laws in Norway and Sweden. </p>
+        <p className="lead">At {brandTitle} we value accessibility. Our products are meant to be used by people no matter of their abilities and therefor we strive to be WCAG (Web Content Accessibility Guidelines) compliant. We’re currently working on our accessibility awareness and meeting the terms of the  accessibility laws in Norway and Sweden. </p>
         <h2>What is accessibility</h2>
         <p>Accessibility ties back to our values <span>simple</span> and <span>caring</span>.About 15 percent of the western world’s population is living with a disability of some kind. This translates to over 1 billion people, and includes visual, auditory, physical, speech, cognitive, and neurological disabilities. </p>
 
@@ -18,7 +21,7 @@ const Intro = () => (
             <span className="caption-text"><span className="font-weight-bold">Figure 1.</span> An illustration visualizing permanent, beneath temporary and situational impairment.</span>
         </div>
 
-        <p>At Swedbank Pay we strive to give all customers with disabilities and impairments (permanent, temporary and/or situational) a better chance of using our services on the same terms as others. </p>
+        <p>At {brandTitle} we strive to give all customers with disabilities and impairments (permanent, temporary and/or situational) a better chance of using our services on the same terms as others. </p>
     </section>
 );
 
@@ -57,7 +60,7 @@ const WcagStandard = () => (
 const Inclusions = () => (
     <section>
         <h2 id="inclusions">Creating inclusion</h2>
-        <p>Today we’re working with awareness. All designers and developers at Swedbank Pay should be aware of accessibility, what it is, how it’s implemented and, what precautions we have to take to actually follow the law in the countries we’re in. As mentioned, accessibility may start with design but the main part is making our service compatible with accessibility helping tools, and that part happens in the technical implementation. </p>
+        <p>Today we’re working with awareness. All designers and developers at {brandTitle} should be aware of accessibility, what it is, how it’s implemented and, what precautions we have to take to actually follow the law in the countries we’re in. As mentioned, accessibility may start with design but the main part is making our service compatible with accessibility helping tools, and that part happens in the technical implementation. </p>
         <p>Accessibility and WCAG can seem overwhelming and just as with everything else we need to take it step by step. This is a list from a Funka webinar held 2020-11-06:</p>
         <ul className="list list-bullet">
             <li>Make sure that we know the current status of our products. Are we accessible enough?</li>
@@ -91,7 +94,7 @@ const DiveDeeper = () => (
         ))}
 
         <h3>Others about accessibility</h3>
-        {externalLinks.othersAboutAccessibility.map(links => (
+        {otherLinks.map(links => (
             <a key={links.url} href={links.url} target="_blank" rel="noopener noreferrer" className="icon-link d-flex">
                 <i className="material-icons mr-2" aria-hidden="true">open_in_new</i>
                 <span className="mr-2">{links.text}</span>

--- a/src/App/Identity/identity/Copywriting/__snapshots__/index.test.js.snap
+++ b/src/App/Identity/identity/Copywriting/__snapshots__/index.test.js.snap
@@ -17,7 +17,9 @@ exports[`Core: Accessibility AccessibleService renders 1`] = `
     Brand tonality in UX writing
   </h3>
   <p>
-    The brand tonality goes hand in hand with the UX Writing principles. By following the principles for UX Writing we also stay on brand. And vice versa. They are very similar. Open, simple and caring is the basis for Swedbank Pay’s communication.
+    The brand tonality goes hand in hand with the UX Writing principles. By following the principles for UX Writing we also stay on brand. And vice versa. They are very similar. Open, simple and caring is the basis for 
+    TESTBRAND
+    ’s communication.
   </p>
   <p
     className="mb-0"
@@ -95,7 +97,8 @@ exports[`Core: Accessibility AccessibleService renders 1`] = `
           <th
             className="w-50"
           >
-            Swedbank Pay tonality
+            TESTBRAND
+             tonality
           </th>
         </tr>
       </thead>
@@ -134,7 +137,9 @@ exports[`Core: Accessibility AccessibleService renders 1`] = `
       >
         Table 1.
       </span>
-       Three examples of tonality – general vs. Swedbank Pay tonality.
+       Three examples of tonality – general vs. 
+      TESTBRAND
+       tonality.
     </span>
   </div>
   <h3>
@@ -159,17 +164,20 @@ exports[`Core: Accessibility AccessibleService renders 1`] = `
           <th
             className="w-50"
           >
-            Swedbank Pay interface writing
+            TESTBRAND
+             interface writing
           </th>
         </tr>
       </thead>
       <tbody>
         <tr>
           <td>
-            By completing the purchase, I confirm that I have read and approve of Swedbank Pay's terms and conditions.
+            By completing the purchase, I confirm that I have read and approve of {brandTitle}'s terms and conditions.
           </td>
           <td>
-            By paying, you also confirm the Swedbank Pay terms and conditions.
+            By paying, you also confirm the 
+            TESTBRAND
+             terms and conditions.
           </td>
         </tr>
         <tr>
@@ -238,7 +246,9 @@ exports[`Core: Accessibility AccessibleService renders 1`] = `
       >
         Table 2.
       </span>
-       Eight examples on common general interface with Swedbank Pay tonality translations.
+       Eight examples on common general interface with 
+      TESTBRAND
+       tonality translations.
     </span>
   </div>
 </section>
@@ -258,7 +268,9 @@ exports[`Core: Accessibility Intro renders 1`] = `
     Copy
   </h3>
   <p>
-    Copy is defined as written content that aims to increase brand awareness and ultimately persuade a person or group to take a particular action. Quite a lot falls under this umbrella but in the context of Swedbank Pay, an example of “pure” copy is the short texts you see on the website aiming to explain and “sell” the brand/product (see Figure 1).
+    Copy is defined as written content that aims to increase brand awareness and ultimately persuade a person or group to take a particular action. Quite a lot falls under this umbrella but in the context of 
+    TESTBRAND
+    , an example of “pure” copy is the short texts you see on the website aiming to explain and “sell” the brand/product (see Figure 1).
   </p>
   <div
     className="d-flex flex-column align-items-center"
@@ -276,7 +288,9 @@ exports[`Core: Accessibility Intro renders 1`] = `
       >
         Figure 1.
       </span>
-       This is an example of “pure” copy text from swedbankpay.se
+       This is an example of “pure” copy text from 
+      TESTBRAND
+      .se
     </span>
   </div>
   <h3>
@@ -407,10 +421,13 @@ exports[`Core: Accessibility renders 1`] = `
   <p
     className="lead"
   >
-    At Swedbank Pay we care about how we’re interpreted by our customers and merchants. In this section you will find an overview of the different kinds of written content relevant for Swedbank Pay, tonality principles, a glossary, and links to further information.
+    At 
+    TESTBRAND
+     we care about how we’re interpreted by our customers and merchants. In this section you will find an overview of the different kinds of written content relevant for 
+    TESTBRAND
+    , tonality principles, a glossary, and links to further information.
   </p>
   <Terminology />
   <Tonality />
-  <GlossaryLinks />
 </DocContainer>
 `;

--- a/src/App/Identity/identity/Copywriting/index.js
+++ b/src/App/Identity/identity/Copywriting/index.js
@@ -2,6 +2,8 @@ import React from "react";
 import { DocContainer } from "@docutils";
 
 const basename = process.env.basename;
+const brandTitle = process.env.brandTitle;
+const brand = process.env.brand;
 
 const Terminology = () => (
     <section>
@@ -11,12 +13,12 @@ const Terminology = () => (
         <h3>Copy</h3>
         <p>
             Copy is defined as written content that aims to increase brand awareness and ultimately persuade a person or group to take a particular action.
-            Quite a lot falls under this umbrella but in the context of Swedbank Pay,
+            Quite a lot falls under this umbrella but in the context of {brandTitle},
             an example of “pure” copy is the short texts you see on the website aiming to explain and “sell” the brand/product (see Figure 1).
         </p>
         <div className="d-flex flex-column align-items-center">
             <img src={`${basename}img/documentation/copywriting/terminology-copy.png`} className="mb-1 w-100" alt="Copy text" />
-            <span className="caption-text"><span className="font-weight-bold">Figure 1.</span> This is an example of “pure” copy text from swedbankpay.se</span>
+            <span className="caption-text"><span className="font-weight-bold">Figure 1.</span> This is an example of “pure” copy text from {brand}.se</span>
         </div>
 
         <h3>Microcopy</h3>
@@ -62,7 +64,7 @@ const Tonality = () => (
         <h3>Brand tonality in UX writing</h3>
         <p>
             The brand tonality goes hand in hand with the UX Writing principles. By following the principles for UX Writing we also stay on brand. And vice versa. They are very similar.
-            Open, simple and caring is the basis for Swedbank Pay’s communication.
+            Open, simple and caring is the basis for {brandTitle}’s communication.
         </p>
         <p className="mb-0">
             We apply this by:
@@ -107,7 +109,7 @@ const Tonality = () => (
                 <thead>
                     <tr>
                         <th className="w-50">General tonality</th>
-                        <th className="w-50">Swedbank Pay tonality</th>
+                        <th className="w-50">{brandTitle} tonality</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -128,7 +130,7 @@ const Tonality = () => (
                     </tr>
                 </tbody>
             </table>
-            <span className="caption-text"><span className="font-weight-bold">Table 1.</span> Three examples of tonality – general vs. Swedbank Pay tonality.</span>
+            <span className="caption-text"><span className="font-weight-bold">Table 1.</span> Three examples of tonality – general vs. {brandTitle} tonality.</span>
         </div>
 
         <h3>Importance of interface writing</h3>
@@ -141,13 +143,13 @@ const Tonality = () => (
                 <thead>
                     <tr>
                         <th className="w-50">General interface writing</th>
-                        <th className="w-50">Swedbank Pay interface writing</th>
+                        <th className="w-50">{brandTitle} interface writing</th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr>
-                        <td>{"By completing the purchase, I confirm that I have read and approve of Swedbank Pay's terms and conditions."}</td>
-                        <td>By paying, you also confirm the Swedbank Pay terms and conditions.</td>
+                        <td>{"By completing the purchase, I confirm that I have read and approve of {brandTitle}'s terms and conditions."}</td>
+                        <td>By paying, you also confirm the {brandTitle} terms and conditions.</td>
                     </tr>
                     <tr>
                         <td>Purchase history</td>
@@ -179,7 +181,7 @@ const Tonality = () => (
                     </tr>
                 </tbody>
             </table>
-            <span className="caption-text"><span className="font-weight-bold">Table 2.</span> Eight examples on common general interface with Swedbank Pay tonality translations.</span>
+            <span className="caption-text"><span className="font-weight-bold">Table 2.</span> Eight examples on common general interface with {brandTitle} tonality translations.</span>
         </div>
     </section>
 );
@@ -220,13 +222,13 @@ const GlossaryLinks = () => (
 const Copywriting = () => (
     <DocContainer>
         <p className="lead">
-            At Swedbank Pay we care about how we’re interpreted by our customers and merchants.
-            In this section you will find an overview of the different kinds of written content relevant for Swedbank Pay,
+            At {brandTitle} we care about how we’re interpreted by our customers and merchants.
+            In this section you will find an overview of the different kinds of written content relevant for {brandTitle},
             tonality principles, a glossary, and links to further information.
         </p>
         <Terminology />
         <Tonality />
-        <GlossaryLinks />
+        {brandTitle === "Swedbank Pay" && <GlossaryLinks />}
     </DocContainer>
 );
 

--- a/src/App/Identity/identity/Grid/__snapshots__/index.test.js.snap
+++ b/src/App/Identity/identity/Grid/__snapshots__/index.test.js.snap
@@ -731,7 +731,9 @@ exports[`Core: Grid GridOptions renders 1`] = `
     Grid options
   </h2>
   <p>
-    Most sizes in the Swedbank Pay DesignGuide is defined using 
+    Most sizes in the 
+    TESTBRAND
+     DesignGuide is defined using 
     <CodeTags
       code="rem"
       type="secondary"

--- a/src/App/Identity/identity/Grid/index.js
+++ b/src/App/Identity/identity/Grid/index.js
@@ -196,7 +196,7 @@ const HowItWorks = () => (
 const GridOptions = () => (
     <>
         <h2 id="grid-options">Grid options</h2>
-        <p>Most sizes in the Swedbank Pay DesignGuide is defined using <CodeTags type="secondary" code="rem" />s, <CodeTags type="secondary" code="px" />s are used for grid breakpoints and container widths. This is because the viewport width is in pixels and does not change with the font size.</p>
+        <p>Most sizes in the {process.env.brandTitle} DesignGuide is defined using <CodeTags type="secondary" code="rem" />s, <CodeTags type="secondary" code="px" />s are used for grid breakpoints and container widths. This is because the viewport width is in pixels and does not change with the font size.</p>
         <p>Use this table to see how aspects of the grid system work across multiple devices.</p>
         <table className="table table-striped">
             <thead>

--- a/src/App/Identity/identity/Iconography/__snapshots__/index.test.js.snap
+++ b/src/App/Identity/identity/Iconography/__snapshots__/index.test.js.snap
@@ -909,7 +909,11 @@ exports[`Core: Iconography PaymentIcons renders 1`] = `
     Payment icons
   </h2>
   <p>
-    Below is a list of payment icons that we use in our products. Be mindful when using payment logotypes. Try to make the payment icon feel more secondary in combination with the Swedbank Pay logotype. We always want the Swedbank Pay logotype to be primary.
+    Below is a list of payment icons that we use in our products. Be mindful when using payment logotypes. Try to make the payment icon feel more secondary in combination with the 
+    TESTBRAND
+     logotype. We always want the 
+    TESTBRAND
+     logotype to be primary.
   </p>
   <h3>
     Example of how to implement payment icons
@@ -1109,7 +1113,9 @@ exports[`Core: Iconography renders 1`] = `
   <p
     className="lead"
   >
-    At Swedbank Pay we use Material icons from Material Design, but we also include icons for well-known payment providers, and flags for most nations in the world. All icons are integrated and are available in HTML and CSS.
+    At 
+    TESTBRAND
+     we use Material icons from Material Design, but we also include icons for well-known payment providers, and flags for most nations in the world. All icons are integrated and are available in HTML and CSS.
   </p>
   <MaterialIcons />
   <CardIcons />

--- a/src/App/Identity/identity/Iconography/index.js
+++ b/src/App/Identity/identity/Iconography/index.js
@@ -5,6 +5,8 @@ import { ComponentPreview, DocContainer } from "@docutils";
 import IconPreview from "@components/IconPreview";
 import CodeTags from "@components/CodeTags";
 
+const brandTitle = process.env.brandTitle;
+
 const MaterialIcons = () => (
     <section>
         <h2 id="material-rounded-icons">Material Outlined Icons</h2>
@@ -71,7 +73,7 @@ const CardIcons = () => (
 const PaymentIcons = () => (
     <section>
         <h2 id="payment-icons">Payment icons</h2>
-        <p>Below is a list of payment icons that we use in our products. Be mindful when using payment logotypes. Try to make the payment icon feel more secondary in combination with the Swedbank Pay logotype. We always want the Swedbank Pay logotype to be primary.</p>
+        <p>Below is a list of payment icons that we use in our products. Be mindful when using payment logotypes. Try to make the payment icon feel more secondary in combination with the {brandTitle} logotype. We always want the {brandTitle} logotype to be primary.</p>
 
         <h3>Example of how to implement payment icons</h3>
         <p>To use an icon, provide the following markup: <CodeTags type="primary" code={"<i class=\"payment-icon payment-icon-{icon-name}\" aria-hidden=\"true\" /i>"} /></p>
@@ -173,7 +175,7 @@ const Flags = () => (
 const Iconography = () => (
     <DocContainer>
         <p className="lead">
-        At Swedbank Pay we use Material icons from Material Design, but we also include icons for well-known payment providers, and flags for most nations in the world. All icons are integrated and are available in HTML and CSS.
+        At {brandTitle} we use Material icons from Material Design, but we also include icons for well-known payment providers, and flags for most nations in the world. All icons are integrated and are available in HTML and CSS.
         </p>
         <MaterialIcons />
         <CardIcons />

--- a/src/App/Identity/identity/Identity/__snapshots__/index.test.js.snap
+++ b/src/App/Identity/identity/Identity/__snapshots__/index.test.js.snap
@@ -162,7 +162,7 @@ exports[`Identity: Identity MenuOverview renders 1`] = `
           Logotype
         </span>
         <span>
-          The Swedbank Pay logotype
+          The TESTBRAND logotype
         </span>
       </div>
       <i
@@ -262,31 +262,14 @@ exports[`Identity: Identity OurBrand renders 1`] = `
     </p>
   </blockquote>
   <h3>
-    Swedbank Pay design principles
+    TESTBRAND
+     design principles
   </h3>
   <p
     className="m-0"
   >
     We let our design principles reflect our brand values. When designing, we try to be warm and welcoming in our tonality. By being consistent with our interactions, involving our users, and ensuring access for all, we strive to create trust and guide our users to complete their tasks successfully.
   </p>
-  <a
-    className="icon-link"
-    href="https://brand-manager.swedbank.com/start/guidelines/swedbank-pay.html"
-    rel="noopener noreferrer"
-    target="_blank"
-  >
-    <i
-      aria-hidden="true"
-      className="material-icons"
-    >
-      open_in_new
-    </i>
-    <span
-      className="ml-2"
-    >
-      Swedbank Brand Manager – read more about our brand
-    </span>
-  </a>
 </section>
 `;
 

--- a/src/App/Identity/identity/Identity/index.js
+++ b/src/App/Identity/identity/Identity/index.js
@@ -3,6 +3,8 @@ import { Link } from "react-router-dom";
 import overviewList from "@src/App/routes/identity";
 import { DocContainer } from "@docutils";
 
+const brandTitle = process.env.brandTitle;
+
 const OurBrand = () => (
     <section>
         <h2 id="our-brand">Our brand</h2>
@@ -12,12 +14,12 @@ const OurBrand = () => (
             <p>We are warm and welcoming, we guide, we involve users, we ensure access for all, we are consistent and we design for trust.</p>
         </blockquote>
 
-        <h3>Swedbank Pay design principles</h3>
+        <h3>{brandTitle} design principles</h3>
         <p className="m-0">We let our design principles reflect our brand values. When designing, we try to be warm and welcoming in our tonality. By being consistent with our interactions, involving our users, and ensuring access for all, we strive to create trust and guide our users to complete their tasks successfully.</p>
-        <a href="https://brand-manager.swedbank.com/start/guidelines/swedbank-pay.html" target="_blank" rel="noopener noreferrer"className="icon-link">
+        {brandTitle === "Swedbank pay" && <a href="https://brand-manager.swedbank.com/start/guidelines/swedbank-pay.html" target="_blank" rel="noopener noreferrer"className="icon-link">
             <i className="material-icons" aria-hidden="true">open_in_new</i>
             <span className="ml-2">Swedbank Brand Manager – read more about our brand</span>
-        </a>
+        </a>}
     </section>
 );
 

--- a/src/App/Identity/identity/Imagery/__snapshots__/index.test.js.snap
+++ b/src/App/Identity/identity/Imagery/__snapshots__/index.test.js.snap
@@ -54,26 +54,14 @@ exports[`Core: Imagery ImageLibrary renders 1`] = `
     Image library
   </h2>
   <p>
-    All images displayed in a Swedbank Pay interface should be from the Swedbank Pay Image library. Note that the images only can be used in Swedbank Pay productions. If you need access to the library, contact current Head of Marketing. 
+    All images displayed in a 
+    TESTBRAND
+     interface should be from the 
+    TESTBRAND
+     Image library. Note that the images only can be used in 
+    TESTBRAND
+     productions. If you need access to the library, contact current Head of Marketing. 
   </p>
-  <a
-    className="icon-link d-block d-flex"
-    href="https://payex.pickit.com/"
-    rel="noopener noreferrer"
-    target="_blank"
-  >
-    <i
-      aria-hidden="true"
-      className="material-icons mr-2"
-    >
-      open_in_new
-    </i>
-    <span
-      className="mr-2"
-    >
-      Visit the Swedbank Pay Image Library
-    </span>
-  </a>
   <img
     alt="collection of images"
     className="w-100"
@@ -83,7 +71,13 @@ exports[`Core: Imagery ImageLibrary renders 1`] = `
     Finding the right images
   </h3>
   <p>
-    There are several images to choose from when working with Swedbank Pay products. Because Swedbank Pay is a payment service for all, it’s extra important to think about diversity when picking images for a product. To choose a great image, reflect over the context you’re bringing the image into and check if and where the image is used in other Swedbank Pay products. If an images is strongly associated with a certain page or feature, consider using another. We strive to use a variation of the library images while also giving the image a purpose. 
+    There are several images to choose from when working with 
+    TESTBRAND
+     products. Because 
+    TESTBRAND
+     is a payment service for all, it’s extra important to think about diversity when picking images for a product. To choose a great image, reflect over the context you’re bringing the image into and check if and where the image is used in other 
+    TESTBRAND
+     products. If an images is strongly associated with a certain page or feature, consider using another. We strive to use a variation of the library images while also giving the image a purpose. 
   </p>
   <p>
     <span

--- a/src/App/Identity/identity/Imagery/index.js
+++ b/src/App/Identity/identity/Imagery/index.js
@@ -2,15 +2,20 @@ import React from "react";
 import { DocContainer } from "@docutils";
 
 const basename = process.env.basename;
+const brandTitle = process.env.brandTitle;
 
 const ImageLibrary = () => (
     <section>
         <h2 id="image-library">Image library</h2>
-        <p>All images displayed in a Swedbank Pay interface should be from the Swedbank Pay Image library. Note that the images only can be used in Swedbank Pay productions. If you need access to the library, contact current Head of Marketing. </p>
-        <a href="https://payex.pickit.com/" target="_blank" rel="noopener noreferrer" className="icon-link d-block d-flex"><i className="material-icons mr-2" aria-hidden="true">open_in_new</i><span className="mr-2">Visit the Swedbank Pay Image Library</span></a>
+        <p>All images displayed in a {brandTitle} interface should be from the {brandTitle} Image library. Note that the images only can be used in {brandTitle} productions. If you need access to the library, contact current Head of Marketing. </p>
+
+        {brandTitle === "Swedbank Pay" &&
+            <a href="https://payex.pickit.com/" target="_blank" rel="noopener noreferrer" className="icon-link d-block d-flex"><i className="material-icons mr-2" aria-hidden="true">open_in_new</i><span className="mr-2">Visit the Swedbank Pay Image Library</span></a>
+        }
         <img src={`${basename}img/documentation/imagery/image-group.svg`} className="w-100" alt="collection of images"/>
+
         <h3>Finding the right images</h3>
-        <p>There are several images to choose from when working with Swedbank Pay products. Because Swedbank Pay is a payment service for all, it’s extra important to think about diversity when picking images for a product. To choose a great image, reflect over the context you’re bringing the image into and check if and where the image is used in other Swedbank Pay products. If an images is strongly associated with a certain page or feature, consider using another. We strive to use a variation of the library images while also giving the image a purpose. </p>
+        <p>There are several images to choose from when working with {brandTitle} products. Because {brandTitle} is a payment service for all, it’s extra important to think about diversity when picking images for a product. To choose a great image, reflect over the context you’re bringing the image into and check if and where the image is used in other {brandTitle} products. If an images is strongly associated with a certain page or feature, consider using another. We strive to use a variation of the library images while also giving the image a purpose. </p>
         <p><span className="font-weight-bold">TIP</span>: Once you’ve found a picture you think might work, try it in Figma – if it doesn’t work, keep looking and try again!</p>
     </section>
 );

--- a/src/App/Identity/identity/Typography/__snapshots__/index.test.js.snap
+++ b/src/App/Identity/identity/Typography/__snapshots__/index.test.js.snap
@@ -746,7 +746,8 @@ exports[`Core: Typography Headings renders 1`] = `
     Headings
   </h2>
   <p>
-    Swedbank Pay DesignGuide provides basic styling on all headings (h1-h6).
+    TESTBRAND
+     DesignGuide provides basic styling on all headings (h1-h6).
   </p>
   <ComponentPreview
     codeFigure={true}

--- a/src/App/Identity/identity/Typography/index.js
+++ b/src/App/Identity/identity/Typography/index.js
@@ -306,7 +306,7 @@ const Code = () => (
 const Headings = () => (
     <>
         <h2 id="headings">Headings</h2>
-        <p>Swedbank Pay DesignGuide provides basic styling on all headings (h1-h6).</p>
+        <p>{process.env.brandTitle} DesignGuide provides basic styling on all headings (h1-h6).</p>
         <ComponentPreview language="html" showCasePanel codeFigure>
             <h1>Heading h1</h1>
             <h2>Heading h2</h2>

--- a/src/App/__snapshots__/index.test.js.snap
+++ b/src/App/__snapshots__/index.test.js.snap
@@ -154,7 +154,7 @@ exports[`Main: App renders 1`] = `
                       "statusBadges": Array [
                         "updated",
                       ],
-                      "text": "The Swedbank Pay logotype",
+                      "text": "The TESTBRAND logotype",
                       "title": "Logotype",
                     },
                     Object {

--- a/src/App/components/Sidebar/__snapshots__/index.test.js.snap
+++ b/src/App/components/Sidebar/__snapshots__/index.test.js.snap
@@ -15,7 +15,7 @@ exports[`Component: Sidebar renders 1`] = `
         href="/"
       >
         <Logotype
-          alt="Swedbank Pay vertical logo"
+          alt="TESTBRAND vertical logo"
           size="md"
           src="/TEST/designguide/assets/TESTBRAND-logo-v.svg"
           type="vertical"
@@ -202,7 +202,7 @@ exports[`Component: Sidebar renders four levels when four levels is provided 1`]
         href="/"
       >
         <Logotype
-          alt="Swedbank Pay vertical logo"
+          alt="TESTBRAND vertical logo"
           size="md"
           src="/TEST/designguide/assets/TESTBRAND-logo-v.svg"
           type="vertical"
@@ -346,7 +346,7 @@ exports[`Component: Sidebar renders one level when one level is provided 1`] = `
         href="/"
       >
         <Logotype
-          alt="Swedbank Pay vertical logo"
+          alt="TESTBRAND vertical logo"
           size="md"
           src="/TEST/designguide/assets/TESTBRAND-logo-v.svg"
           type="vertical"
@@ -408,7 +408,7 @@ exports[`Component: Sidebar renders three levels when three levels is provided 1
         href="/"
       >
         <Logotype
-          alt="Swedbank Pay vertical logo"
+          alt="TESTBRAND vertical logo"
           size="md"
           src="/TEST/designguide/assets/TESTBRAND-logo-v.svg"
           type="vertical"
@@ -509,7 +509,7 @@ exports[`Component: Sidebar renders two levels when two levels is provided 1`] =
         href="/"
       >
         <Logotype
-          alt="Swedbank Pay vertical logo"
+          alt="TESTBRAND vertical logo"
           size="md"
           src="/TEST/designguide/assets/TESTBRAND-logo-v.svg"
           type="vertical"

--- a/src/App/components/Sidebar/index.js
+++ b/src/App/components/Sidebar/index.js
@@ -13,7 +13,7 @@ class Sidebar extends Component {
                 <nav className="sidebar-main-nav">
                     <div className="sidebar-logo">
                         <a href="/">
-                            <LogotypeComponent src={`${basename}designguide/assets/${brand}-logo-v.svg`} size="md" alt="Swedbank Pay vertical logo" type="vertical" />
+                            <LogotypeComponent src={`${basename}designguide/assets/${brand}-logo-v.svg`} size="md" alt={`${process.env.brandTitle} vertical logo`} type="vertical" />
                         </a>
                     </div>
                     <ul className="main-nav-ul">

--- a/src/App/components/Topbar/__snapshots__/index.test.js.snap
+++ b/src/App/components/Topbar/__snapshots__/index.test.js.snap
@@ -581,13 +581,13 @@ exports[`Component: Topbar - props topbarContent renders a sidebar in topbar-lin
                     href="/"
                   >
                     <Logotype
-                      alt="Swedbank Pay vertical logo"
+                      alt="TESTBRAND vertical logo"
                       size="md"
                       src="/TEST/designguide/assets/TESTBRAND-logo-v.svg"
                       type="vertical"
                     >
                       <img
-                        alt="Swedbank Pay vertical logo"
+                        alt="TESTBRAND vertical logo"
                         className="logotype-vertical logotype-md"
                         src="/TEST/designguide/assets/TESTBRAND-logo-v.svg"
                       />

--- a/src/App/routes/identity.js
+++ b/src/App/routes/identity.js
@@ -65,7 +65,7 @@ module.exports = [
                 path: "/identity/logotype",
                 componentPath: "identity/Logotype",
                 statusBadges: ["updated"],
-                text: "The Swedbank Pay logotype"
+                text: `The ${process.env.brandTitle} logotype`
             },
             {
                 title: "Page layout",

--- a/src/App/utils/RenderPage/__snapshots__/index.test.js.snap
+++ b/src/App/utils/RenderPage/__snapshots__/index.test.js.snap
@@ -144,7 +144,7 @@ exports[`Utilities: RenderPage renders 1`] = `
               "statusBadges": Array [
                 "updated",
               ],
-              "text": "The Swedbank Pay logotype",
+              "text": "The TESTBRAND logotype",
               "title": "Logotype",
             },
             Object {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Made brand titles switch between Swedbank Pay and Payex.
Also made some documentation examples dynamic too.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Can not show Swedbank Pay brand when user is on Payex Design guide

## How Has This Been Tested?
Launched Payex and searched for "Swedbank Pay" on each page.
Updated snapshots. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
