### PR TITLE
Release/7.0.1 (develop)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,33 +1,22 @@
 # Changelog
 
-## [7.0.0] - 13.09.2021
+## [7.0.1] - 23.09.2021
 
-## Added
-- Favicon section under Logotypes
-- Copy to clipboard
-- "For" attribute for Input fields
 ## Changed
-- Tabs
-  - Changed styling on component
-  - Content on documentation page
-- Change styling and documentation page on
-  - Alert
-  - Loader
-  - Tabs
-  - Links
-- Changed content on
-  - Checkbox
-  - Radiobutton
-  - Togglebox
-  - Rangeslider
-  - Select
-  - Input field
-- Changed options labels on Cards page
-- Updated badges on pages
+- Content on Links page
 
 ## Fixed
-- Payex design guide
-- Broken link in imagery
+- Tab issues on leaf nodes in sidebar
+- Screen reader reading the bubble images on the home page
+- Border radius bug on a:focus
+- Topbar missing focus state
+- Input field > Autocomplete section not showing "autocomplete"-attribute
+- Content in component overview not centered when option menu was closed
+- A lot of links not pointing to the right direction
 
-## Removed
-- alert-complex class
+- Safari bugs
+  - Line breaks and text ends up outside of tooltip
+  - Tabs scrollable shadow
+  - Help icon for checkbox and radio button was not align correct
+  - Default checkbox showed up on Togglebox
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 - Content on Links page
 
 ## Fixed
-- Tab issues on leaf nodes in sidebar
 - Screen reader reading the bubble images on the home page
 - Border radius bug on a:focus
 - Topbar missing focus state

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swedbankpay/design-guide",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "description": "Swedbank Pay Design Guide",
   "main": "dist/designguide/scripts/dg.js",
   "scripts": {

--- a/src/App/ComponentsDocumentation/components/InputField/__snapshots__/index.test.js.snap
+++ b/src/App/ComponentsDocumentation/components/InputField/__snapshots__/index.test.js.snap
@@ -39,7 +39,7 @@ exports[`Component: InputField ContentGuidelines renders 1`] = `
     Input label
   </h3>
   <p>
-    A input field must have a label that clearly describes the type of input a field requires. 
+    An input field must have a label that clearly describes the type of input a field requires. 
   </p>
   <ul
     className="list list-bullet"
@@ -488,7 +488,7 @@ exports[`Component: InputField Textarea renders 1`] = `
               placeholder="Placeholder text"
               type="textarea"
             />,
-            "description": "Text areas have a few different sates which includes the default state, focus state, disabled state and error state. ",
+            "description": "Textareas have a few different sates which includes the default state, focus state, disabled state and error state. ",
             "options": Object {
               "checkbox": Array [
                 Object {

--- a/src/App/ComponentsDocumentation/components/InputField/constants.js
+++ b/src/App/ComponentsDocumentation/components/InputField/constants.js
@@ -174,7 +174,7 @@ export const textareaShowCase = {
                 ]
             },
             title: "Textarea",
-            description: "Text areas have a few different sates which includes the default state, focus state, disabled state and error state. "
+            description: "Textareas have a few different sates which includes the default state, focus state, disabled state and error state. "
         }
     ]
 };

--- a/src/App/ComponentsDocumentation/components/InputField/index.js
+++ b/src/App/ComponentsDocumentation/components/InputField/index.js
@@ -43,7 +43,7 @@ const ContentGuidelines = forwardRef((props, ref) => <section ref={ref}>
     </div>
 
     <h3>Input label</h3>
-    <p>A input field must have a label that clearly describes the type of input a field requires. </p>
+    <p>An input field must have a label that clearly describes the type of input a field requires. </p>
     <ul className="list list-bullet">
         <li>Use a label that is meaningful, clear, and concise.</li>
         <li>When a text field is not required to be filled by the user, label it as “optional”.</li>

--- a/src/App/Home/constants.js
+++ b/src/App/Home/constants.js
@@ -1,5 +1,10 @@
 export const changeLogs = [
     {
+        version: "7.0.1",
+        title: "A patch of love",
+        text: "Some things didn’t end up looking the way we wanted them (Safari, we're mostly looking at you). This patch will remove some styling bugs from previous release."
+    },
+    {
         version: "7.0.0",
         title: "Favicon, component updates and copy code feature",
         text: "You asked and we heard you, Favicon assets can now be found in the logotype section. We also redesigned a few of our components and updated the documentation. Goodbye to Tabs looking disabled on hover, Hello new fresh looking Alerts and Loaders. And you know what, you will no longer need to manually copy code from our code viewer since we have a brand new copy code button in place."
@@ -18,10 +23,5 @@ export const changeLogs = [
         version: "6.0.0",
         title: "Splitting up forms component",
         text: "Long time no see! We are back with a bigger update regarding the forms page and its components. In order make it easier to locate the various components (checkbox, select, radio buttons etc) that were included under the name “forms”, you will now be able to find components with a slightly updated design on their own pages with more detailed explanations and guides of usage!"
-    },
-    {
-        version: "5.0.3",
-        title: "Icon patch",
-        text: "Trustly icon patched."
-    },
+    }
 ];

--- a/src/App/utils/RenderPage/__snapshots__/index.test.js.snap
+++ b/src/App/utils/RenderPage/__snapshots__/index.test.js.snap
@@ -13,7 +13,7 @@ exports[`Utilities: RenderPage renders 1`] = `
       className="dg-current-version text-uppercase"
     >
       Design Guide – v. 
-      7.0.0
+      7.0.1
     </span>
     <Switch>
       <Route

--- a/src/less/documentation-swedbankpay.less
+++ b/src/less/documentation-swedbankpay.less
@@ -796,7 +796,7 @@
                 &.active {
                     display: block;
                     min-width: 12.5rem;
-                    overflow-y: scroll;
+                    overflow-y: auto;
                 }
 
                 .options-header {

--- a/src/less/documentation-swedbankpay.less
+++ b/src/less/documentation-swedbankpay.less
@@ -698,6 +698,7 @@
                     position: absolute;
                     top: 0;
                     width: 100%;
+                    border-bottom: none;
 
                     &.tabs-fade-right {
                         &:after {
@@ -741,8 +742,9 @@
             }
 
             .component-preview {
-                padding-top: 2.5rem;
+                margin-top: 2.5rem;
                 border-bottom: 1px solid @brand-secondary-light-3;
+                z-index: 100;
 
                 .component-preview-content {
                     position: relative;

--- a/src/less/documentation-swedbankpay.less
+++ b/src/less/documentation-swedbankpay.less
@@ -772,7 +772,6 @@
 
             .component-description {
                 padding: 2rem;
-                max-width: 40.5rem;
                 height: 100%;
 
                 h3 {

--- a/src/scripts/main/sidebar/index.js
+++ b/src/scripts/main/sidebar/index.js
@@ -338,7 +338,7 @@ const populateSidebarTertiary = (id, leafList) => {
         const newLeafContent = document.createElement("a");
 
         newLeafContent.textContent = leaf.textContent;
-        newLeafContent.href = "javascript:;";
+        // newLeafContent.href = "javascript:;";
         newLeaf.appendChild(newLeafContent);
         newLeaf.classList.add("nav-leaf");
 


### PR DESCRIPTION
# Changelog

## [7.0.1] - 23.09.2021

## Changed
- Content on Links page

## Fixed
- Screen reader reading the bubble images on the home page
- Border radius bug on a:focus
- Topbar missing focus state
- Input field > Autocomplete section not showing "autocomplete"-attribute
- Content in component overview not centered when option menu was closed
- A lot of links not pointing to the right direction

- Safari bugs
  - Line breaks and text ends up outside of tooltip
  - Tabs scrollable shadow
  - Help icon for checkbox and radio button was not align correct
  - Default checkbox showed up on Togglebox

