### PR TITLE
Bug fix adds event listner when user clicks back in dialog state

### DIFF
--- a/src/scripts/main/dialog/index.js
+++ b/src/scripts/main/dialog/index.js
@@ -82,6 +82,12 @@ class Dialog {
                 this.close();
             });
         }
+
+        window.addEventListener("popstate", () => {
+            if (document.body.className.includes("dialog-open")) {
+                document.body.classList.remove("dialog-open");
+            }
+        });
     }
 
     open () {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Resolves #337. 
Update script with new eventlistener for removing "dialog-open" class when changing page. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran all existing tests. 

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have updated the **CHANGELOG** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
