### PR TITLE
Make azure cli overwrite existing blobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,4 +48,4 @@ jobs:
         uses: azure/CLI@v1.0.6
         with:
           inlineScript: |
-            az storage blob upload-batch -s dist -d \$web --account-name ${{ steps.variables.outputs.AZURE_ACCOUNT_STAGE }}
+            az storage blob upload-batch -s dist -d \$web --account-name ${{ steps.variables.outputs.AZURE_ACCOUNT_STAGE }} --overwrite

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -46,7 +46,7 @@ jobs:
         uses: azure/CLI@v1.0.6
         with:
           inlineScript: |
-            az storage blob upload-batch -s dist -d \$web --account-name ${{ steps.variables.outputs.AZURE_ACCOUNT_PROD }}
+            az storage blob upload-batch -s dist -d \$web --account-name ${{ steps.variables.outputs.AZURE_ACCOUNT_PROD }} --overwrite
 
       - name: Create Release
         # Only create a release on one brand to avoid duplicate error


### PR DESCRIPTION
Azure cli has been updated. It no longer overwrites existing blobs by default. 

This PR adds the `--overwrite` flag to deploys.

Ref: https://github.com/Azure/azure-cli/issues/21477