### PR TITLE
Feature/671 anchor element support for pagination arrows fix

### DIFF
--- a/src/App/ComponentsDocumentation/components/Pagination/__snapshots__/index.test.js.snap
+++ b/src/App/ComponentsDocumentation/components/Pagination/__snapshots__/index.test.js.snap
@@ -182,12 +182,7 @@ exports[`Documentation: Pagination Overview renders 1`] = `
                   code="<a>"
                   type="primary"
                 />
-                 tags with the class 
-                <CodeTags
-                  code="anchor"
-                  type="secondary"
-                />
-                .
+                 tags.
               </p>
             </React.Fragment>,
             "title": "Pagination",

--- a/src/App/ComponentsDocumentation/components/Pagination/__snapshots__/index.test.js.snap
+++ b/src/App/ComponentsDocumentation/components/Pagination/__snapshots__/index.test.js.snap
@@ -176,6 +176,19 @@ exports[`Documentation: Pagination Overview renders 1`] = `
               <p>
                 The pagination component consist of page number links as well as arrows to go to next or previous page. The arrow to previous page is disabled when the first page is active and the next arrow when the last page is active. If there are 7 pages or fewer, all page number links will be shown, but if there are more pages an ellipsis is used to truncate the pages as follows: [first] ... [current-1] [current] [current+1] ... [last].
               </p>
+              <p>
+                The arrows can also be 
+                <CodeTags
+                  code="<a>"
+                  type="primary"
+                />
+                 tags with the class 
+                <CodeTags
+                  code="anchor"
+                  type="secondary"
+                />
+                .
+              </p>
             </React.Fragment>,
             "title": "Pagination",
           },

--- a/src/App/ComponentsDocumentation/components/Pagination/constants.js
+++ b/src/App/ComponentsDocumentation/components/Pagination/constants.js
@@ -11,7 +11,7 @@ export const PaginationShowCasePanel = {
             title: "Pagination",
             description: <>
                 <p>The pagination component consist of page number links as well as arrows to go to next or previous page. The arrow to previous page is disabled when the first page is active and the next arrow when the last page is active. If there are 7 pages or fewer, all page number links will be shown, but if there are more pages an ellipsis is used to truncate the pages as follows: [first] ... [current-1] [current] [current+1] ... [last].</p>
-                <p>The arrows can also be <CodeTags type="primary" code="<a>"/> tags with the class <CodeTags type="secondary" code="anchor"/>.</p>
+                <p>The arrows can also be <CodeTags type="primary" code="<a>"/> tags.</p>
             </>
         }
     ]

--- a/src/App/ComponentsDocumentation/components/Pagination/constants.js
+++ b/src/App/ComponentsDocumentation/components/Pagination/constants.js
@@ -1,5 +1,6 @@
 import React from "react";
-import Pagination from "~/src/App/components/Pagination";
+import Pagination from "@components/Pagination";
+import CodeTags from "@components/CodeTags";
 
 export const PaginationShowCasePanel = {
     id: "no-tabs",
@@ -10,6 +11,7 @@ export const PaginationShowCasePanel = {
             title: "Pagination",
             description: <>
                 <p>The pagination component consist of page number links as well as arrows to go to next or previous page. The arrow to previous page is disabled when the first page is active and the next arrow when the last page is active. If there are 7 pages or fewer, all page number links will be shown, but if there are more pages an ellipsis is used to truncate the pages as follows: [first] ... [current-1] [current] [current+1] ... [last].</p>
+                <p>The arrows can also be <CodeTags type="primary" code="<a>"/> tags with the class <CodeTags type="secondary" code="anchor"/>.</p>
             </>
         }
     ]

--- a/src/App/ComponentsDocumentation/components/Pagination/index.js
+++ b/src/App/ComponentsDocumentation/components/Pagination/index.js
@@ -2,7 +2,6 @@ import React from "react";
 
 import { ComponentPreview, DocContainer } from "@docutils";
 import { PaginationShowCasePanel } from "./constants";
-
 import CodeTags from "~/src/App/components/CodeTags";
 
 const Overview = () => (

--- a/src/App/components/Pagination/index.js
+++ b/src/App/components/Pagination/index.js
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import classnames from "classnames";
 import { paginate } from "@src/scripts/main";
 
-const Pagination = ({ length, currentActive, id }) => {
+const Pagination = ({ length, currentActive, id, anchorArrows }) => {
 
     const [current, setCurrent] = useState(currentActive);
 
@@ -17,10 +17,12 @@ const Pagination = ({ length, currentActive, id }) => {
         const arrowClasses = classnames(
             `arrow-${type}`,
             mobile ? "d-block d-sm-none" : null,
-            disabled ? "disabled" : null
+            disabled ? "disabled" : null,
+            anchorArrows ? "anchor" : null
         );
 
-        const navigate = () => {
+        const navigate = (e) => {
+            e.preventDefault();
             if (type === "forward") { setCurrent(current + 1); }
 
             if (type === "back") { setCurrent(current - 1); }
@@ -31,9 +33,18 @@ const Pagination = ({ length, currentActive, id }) => {
         };
 
         return (
-            <button className={arrowClasses} onClick={() => navigate()}>{"\n"}
-                <i className="material-icons" aria-label={type}></i>{"\n"}
-            </button>
+            <>
+            {anchorArrows ? 
+                <a className={arrowClasses} href="#" onClick={e => navigate(e)}>{"\n"}
+                    <i className="material-icons" aria-label={type}></i>{"\n"}
+                </a>
+                : 
+                <button className={arrowClasses} onClick={(e) => navigate(e)}>{"\n"}
+                    <i className="material-icons" aria-label={type}></i>{"\n"}
+                </button>
+            }
+            </>
+            
         );
     };
 
@@ -70,7 +81,8 @@ Pagination.propTypes = {
     text: PropTypes.string,
     arrows: PropTypes.bool,
     mobileView: PropTypes.bool,
-    id: PropTypes.string.isRequired
+    id: PropTypes.string.isRequired,
+    anchorArrows: PropTypes.bool
 };
 
 export default Pagination;

--- a/src/App/components/Pagination/index.js
+++ b/src/App/components/Pagination/index.js
@@ -17,12 +17,12 @@ const Pagination = ({ length, currentActive, id, anchorArrows }) => {
         const arrowClasses = classnames(
             `arrow-${type}`,
             mobile ? "d-block d-sm-none" : null,
-            disabled ? "disabled" : null,
-            anchorArrows ? "anchor" : null
+            disabled ? "disabled" : null
         );
 
-        const navigate = (e) => {
+        const navigate = e => {
             e.preventDefault();
+
             if (type === "forward") { setCurrent(current + 1); }
 
             if (type === "back") { setCurrent(current - 1); }
@@ -34,17 +34,17 @@ const Pagination = ({ length, currentActive, id, anchorArrows }) => {
 
         return (
             <>
-            {anchorArrows ? 
-                <a className={arrowClasses} href="#" onClick={e => navigate(e)}>{"\n"}
-                    <i className="material-icons" aria-label={type}></i>{"\n"}
-                </a>
-                : 
-                <button className={arrowClasses} onClick={(e) => navigate(e)}>{"\n"}
-                    <i className="material-icons" aria-label={type}></i>{"\n"}
-                </button>
-            }
+                {anchorArrows ?
+                    <a className={arrowClasses} href="#" onClick={e => navigate(e)}>{"\n"}
+                        <i className="material-icons" aria-label={type}></i>{"\n"}
+                    </a>
+                    :
+                    <button className={arrowClasses} onClick={e => navigate(e)}>{"\n"}
+                        <i className="material-icons" aria-label={type}></i>{"\n"}
+                    </button>
+                }
             </>
-            
+
         );
     };
 

--- a/src/less/components/pagination.less
+++ b/src/less/components/pagination.less
@@ -18,7 +18,7 @@
     }
 
     button,
-    .anchor {
+    > a {
         all: unset;
         margin: 0.5rem;
         max-height: 1.75rem;

--- a/src/less/components/pagination.less
+++ b/src/less/components/pagination.less
@@ -17,7 +17,8 @@
         }
     }
 
-    button {
+    button,
+    .anchor {
         all: unset;
         margin: 0.5rem;
         max-height: 1.75rem;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Resolves issue #671 . 
<a> tags can be used instead of <button> on arrow elements. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran all tests, updated snapshots.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

## Review instructions
[Review instructions](../REVIEW_INSTRUCTIONS.md)