### PR TITLE
Release 10.2.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,16 +1,19 @@
 # Changelog
 
-## [10.1.0] - 23.06.2022
-## WCAG
--   Support for legibility and usability when zoomed 200% (in the design guide)
--   Correct placement of Toast when called on
--   Update alternate text and captions documentation
--   Update alt-text and captions for all images in DG
--   Added aria-expanded for sidebar-component, both component and the one used in DG
--   Update error icons and error messages in form components
--   Conditional reveals in Patterns/Forms example
--   Update text color for inactive state (badge)
--   Update close buttons to have same style for all components
-
+## [10.2.0] - 18.07.2022
+## Fixes
+-   Pagination script to allow 7 or fewer pages.
+-   Pagination markup bug on arrows.
+-   Color page bug fixes.
+-   Toast alignment bug fix.
+-   Hover state background color on item list is aligned to be the same as hover state background color for tables.
+## Changed
+-   Documentation in get-started/introduction and get-started/for-developers.
+-   Relocated "Open, Simple, Caring"-section from get-started/introduction to identity/introduction.
 ## Added
--   Inactive example in status badge documentation
+-   Videos
+    -   "Contributing to the system" by Filippos Kargiotidis, located in get-started/introduction section.
+    -   "Using Design Guide Light" by Eskil Hognestad, located in get-started/for-developers. 
+-   Design Guide process image in get-started/introduction section.
+## Removed
+-   Snowflake-image in get-started/for-designers.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,6 +13,7 @@
 -   Relocated "Open, Simple, Caring"-section from get-started/introduction to identity/introduction.
 ## Added
 -   Design Guide process image in get-started/introduction section.
+
 -   Videos
     -   "Contributing to the system" by Filippos Kargiotidis, located in get-started/introduction section.
     -   "Using Design Guide Light" by Eskil Hognestad, located in get-started/for-developers.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -13,7 +13,8 @@
 ## Added
 -   Videos
     -   "Contributing to the system" by Filippos Kargiotidis, located in get-started/introduction section.
-    -   "Using Design Guide Light" by Eskil Hognestad, located in get-started/for-developers. 
+    -   "Using Design Guide Light" by Eskil Hognestad, located in get-started/for-developers.
+    
 -   Design Guide process image in get-started/introduction section.
 ## Removed
 -   Snowflake-image in get-started/for-designers.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## [10.2.0] - 18.07.2022
+
 ## Fixes
 -   Pagination script to allow 7 or fewer pages.
 -   Pagination markup bug on arrows.
@@ -14,7 +15,6 @@
 -   Videos
     -   "Contributing to the system" by Filippos Kargiotidis, located in get-started/introduction section.
     -   "Using Design Guide Light" by Eskil Hognestad, located in get-started/for-developers.
-    
 -   Design Guide process image in get-started/introduction section.
 ## Removed
 -   Snowflake-image in get-started/for-designers.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -12,9 +12,9 @@
 -   Documentation in get-started/introduction and get-started/for-developers.
 -   Relocated "Open, Simple, Caring"-section from get-started/introduction to identity/introduction.
 ## Added
+-   Design Guide process image in get-started/introduction section.
 -   Videos
     -   "Contributing to the system" by Filippos Kargiotidis, located in get-started/introduction section.
     -   "Using Design Guide Light" by Eskil Hognestad, located in get-started/for-developers.
--   Design Guide process image in get-started/introduction section.
 ## Removed
 -   Snowflake-image in get-started/for-designers.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swedbankpay/design-guide",
-  "version": "10.1.0",
+  "version": "10.2.0",
   "description": "Swedbank Pay Design Guide",
   "main": "src/scripts/main/index.js",
   "scripts": {

--- a/src/App/Home/constants.js
+++ b/src/App/Home/constants.js
@@ -2,6 +2,11 @@ import React from "react";
 
 export const changeLogs = [
     {
+        version: "10.2.0",
+        title: "Contribution is key 🔑",
+        text: <p>In this release, we have given our contribution sections an update. To have the most robust design system, we need to continuously improve ourselves, which is only doable through the help of our users. Therefore, we have updated our documentation and created two videos; one to emphasize the <a href="/get-started/introduction">contribution process</a>, and one video to show users how to use the new <a href="/get-started/for-developers">Design Guide light</a>. Check them out! This release also includes bug fixes: the pagination script is now supporting lists with seven elements or fewer, markup bug on pagination arrows, and small fixes on the color page. If you find something wrong or weird, do not hesitate to contact us through our slack channel #design-guide-general 🎉</p>
+    },
+    {
         version: "10.1.0",
         title: "WCAG updates",
         text: "Major WCAG update! The design guide is now accessibility-friendly based on the feedback we received from FUNKA 🎉 This version holds mostly technical updates with correct usage of aria-labels, support for zoom up to 200%, and correct placement of the Toast component in the DOM when called on. We also updated our documentation regarding alt-texts and captions. Thank you for all feedback from the last release and findings of bugs 🪲 Enjoy!"

--- a/src/App/utils/RenderPage/__snapshots__/index.test.js.snap
+++ b/src/App/utils/RenderPage/__snapshots__/index.test.js.snap
@@ -13,7 +13,7 @@ exports[`Utilities: RenderPage renders 1`] = `
       className="dg-current-version text-uppercase"
     >
       Design Guide – v. 
-      10.1.0
+      10.2.0
     </span>
     <Switch>
       <Route


### PR DESCRIPTION
# Changelog

## [10.2.0] - 18.07.2022
## Fixes
-   Pagination script to allow 7 or fewer pages.
-   Pagination markup bug on arrows.
-   Color page bug fixes.
-   Toast alignment bug fix.
-   Hover state background color on item list is aligned to be the same as hover state background color for tables.
## Changed
-   Documentation in get-started/introduction and get-started/for-developers.
-   Relocated "Open, Simple, Caring"-section from get-started/introduction to identity/introduction.
## Added
-   Videos
    -   "Contributing to the system" by Filippos Kargiotidis, located in get-started/introduction section.
    -   "Using Design Guide Light" by Eskil Hognestad, located in get-started/for-developers. 
-   Design Guide process image in get-started/introduction section.
## Removed
-   Snowflake-image in get-started/for-designers.
