### PR TITLE
Release 10.4.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,31 +1,29 @@
 # Changelog
 
-## [10.3.0] - 06.09.2022
+## [10.4.0] - 25.10.2022
 
 ## Changed
--   Button component
-    -   Updated design for different states; hover, focus, active, etc.
+- Error icons
+    - Updated error icons to use “warning” icon instead
+- Sheet component
+    - Update z-index for sheet header
+- Pagination component documentation
+    - Showcasing compact version of pagination
+- Pagination component
+    - Update pagination.less to include .compact class for pagination styling as “mobile view”
 
--   Tables component
-    -   Column dividers
-    -   Sorting option
-    -   Handling of buttons
-
--   Tables documentation
-    -   Added do and don't examples on how to structure a table
 ## Added
--   Searchbox for the design system
-    -   Simple search on the different pages of the system.
-    -   Different design for mobile view.
+- Codetags component
+    - Added class for filter tag styling
+- Dropdown component
 
--   Optinal prefers-reduced-animation class
-    -   Components with animations can be turned off if user applies this on their OS.
-    -   Accordion, Expandable, Sidebar, Sheet, Topbar
-
--   Added callback to sheet and dialog component when firing off open/close methods.
-
--   Return Chart instance when new chart() is ran.
-
-## WCAG
--   Menu button on topbar/sidebar mobile view
-    -   aria-haspopup, aria-controls and aria-expanded
+## Bugfixes
+- Input group
+    - Readded postfix for input group elements
+- Searchbox
+    - Visual bug in mobile view fixed
+- Sidebar
+    - Added id for overview in Toast and Tables so it can appear in sidebar
+    - Stop error messages to appear when secondary nav does not have any children
+- Toast documentation page
+    - Anchor linked to wrong page

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swedbankpay/design-guide",
-  "version": "10.3.0",
+  "version": "10.4.0",
   "description": "Swedbank Pay Design Guide",
   "main": "src/scripts/main/index.js",
   "scripts": {

--- a/src/App/Home/constants.js
+++ b/src/App/Home/constants.js
@@ -2,6 +2,14 @@ import React from "react";
 
 export const changeLogs = [
     {
+        version: "10.4.0",
+        title: "New developer New component",
+        text: <p>The design guide team is growing, and so is our component collection! Say hello to our brand new ✨<a href="/components/dropdown">Dropdown</a>✨ component. Check it out!
+            We have also included several changes based on feedback from you guys, our users. Thank you for all your input, and keep’em coming!
+            We have, amongst other things, added filter tags, updated status badges, updated error icons, and resolved a lot of bugs 🐛
+            Head over to the complete changelog to see all the specific changes.</p>
+    },
+    {
         version: "10.3.0",
         title: "Search bar and other treats 🍬",
         text: "Hello to all users of the design guide! In this release, various snacks are provided. First off, in the top right corner, you can see our brand-new search bar! 🔍 This little spinster gives you an alternative way to reach your destination. It is not the most sophisticated search field, but it does the trick! Some WCAG updates have also been made. For instance, the option of reduced animations based on your settings of reducing motion on your OS. Inclusion all the way! Buttons have obtained new designs for their states, and the table component has been modernized, with belonging documentation. Check the changelog to see all the changes."

--- a/src/App/__snapshots__/index.test.js.snap
+++ b/src/App/__snapshots__/index.test.js.snap
@@ -240,7 +240,6 @@ exports[`Main: App renders 1`] = `
                       "path": "/components/checkbox",
                       "statusBadges": Array [
                         "javascript",
-                        "updated",
                       ],
                       "title": "Checkbox",
                     },
@@ -360,7 +359,6 @@ exports[`Main: App renders 1`] = `
                       "path": "/components/radio-button",
                       "statusBadges": Array [
                         "javascript",
-                        "updated",
                       ],
                       "title": "Radio button",
                     },
@@ -371,7 +369,6 @@ exports[`Main: App renders 1`] = `
                       "path": "/components/rangeslider",
                       "statusBadges": Array [
                         "javascript",
-                        "updated",
                       ],
                       "title": "Rangeslider",
                     },
@@ -382,6 +379,7 @@ exports[`Main: App renders 1`] = `
                       "path": "/components/sheet",
                       "statusBadges": Array [
                         "javascript",
+                        "updated",
                       ],
                       "title": "Sheet",
                     },
@@ -392,7 +390,6 @@ exports[`Main: App renders 1`] = `
                       "path": "/components/select",
                       "statusBadges": Array [
                         "javascript",
-                        "updated",
                       ],
                       "title": "Select",
                     },
@@ -403,7 +400,6 @@ exports[`Main: App renders 1`] = `
                       "path": "/components/sidebar",
                       "statusBadges": Array [
                         "javascript",
-                        "updated",
                       ],
                       "title": "Sidebar",
                     },
@@ -412,9 +408,6 @@ exports[`Main: App renders 1`] = `
                       "icon": "skip_next",
                       "outlined": true,
                       "path": "/components/skip-link",
-                      "statusBadges": Array [
-                        "new",
-                      ],
                       "title": "Skip link",
                     },
                     Object {
@@ -429,6 +422,9 @@ exports[`Main: App renders 1`] = `
                       "icon": "check_circle",
                       "outlined": true,
                       "path": "/components/status",
+                      "statusBadges": Array [
+                        "updated",
+                      ],
                       "title": "Status",
                     },
                     Object {
@@ -436,9 +432,6 @@ exports[`Main: App renders 1`] = `
                       "icon": "view_list",
                       "outlined": true,
                       "path": "/components/tables",
-                      "statusBadges": Array [
-                        "updated",
-                      ],
                       "title": "Tables",
                     },
                     Object {
@@ -457,7 +450,7 @@ exports[`Main: App renders 1`] = `
                       "outlined": true,
                       "path": "/components/tags",
                       "statusBadges": Array [
-                        "new",
+                        "updated",
                       ],
                       "title": "Tags",
                     },
@@ -476,9 +469,6 @@ exports[`Main: App renders 1`] = `
                       "icon": "toggle_off",
                       "outlined": true,
                       "path": "/components/togglebox",
-                      "statusBadges": Array [
-                        "updated",
-                      ],
                       "title": "Togglebox",
                     },
                     Object {
@@ -488,7 +478,6 @@ exports[`Main: App renders 1`] = `
                       "path": "/components/tooltips",
                       "statusBadges": Array [
                         "javascript",
-                        "updated",
                       ],
                       "title": "Tooltips",
                     },
@@ -499,7 +488,6 @@ exports[`Main: App renders 1`] = `
                       "path": "/components/topbar",
                       "statusBadges": Array [
                         "javascript",
-                        "updated",
                       ],
                       "title": "Topbar",
                     },

--- a/src/App/routes/components.js
+++ b/src/App/routes/components.js
@@ -82,7 +82,7 @@ module.exports = [
                 componentPath: "components/Checkbox",
                 icon: "check_box",
                 outlined: true,
-                statusBadges: ["javascript", "updated"]
+                statusBadges: ["javascript"]
             },
             {
                 title: "Datepickers",
@@ -183,7 +183,7 @@ module.exports = [
                 path: "/components/radio-button",
                 componentPath: "components/RadioButton",
                 icon: "radio_button_checked",
-                statusBadges: ["javascript", "updated"]
+                statusBadges: ["javascript"]
             },
             {
                 title: "Rangeslider",
@@ -191,7 +191,7 @@ module.exports = [
                 componentPath: "components/Rangeslider",
                 icon: "tune",
                 outlined: true,
-                statusBadges: ["javascript", "updated"]
+                statusBadges: ["javascript"]
             },
             {
                 title: "Sheet",
@@ -199,7 +199,7 @@ module.exports = [
                 componentPath: "components/Sheet",
                 icon: "vertical_split",
                 outlined: true,
-                statusBadges: ["javascript"]
+                statusBadges: ["javascript", "updated"]
             },
             {
                 title: "Select",
@@ -207,7 +207,7 @@ module.exports = [
                 componentPath: "components/Select",
                 icon: "arrow_drop_down_circle",
                 outlined: true,
-                statusBadges: ["javascript", "updated"]
+                statusBadges: ["javascript"]
             },
             {
                 title: "Sidebar",
@@ -215,15 +215,14 @@ module.exports = [
                 componentPath: "components/Sidebar",
                 icon: "view_sidebar",
                 outlined: true,
-                statusBadges: ["javascript", "updated"]
+                statusBadges: ["javascript"]
             },
             {
                 title: "Skip link",
                 path: "/components/skip-link",
                 componentPath: "components/SkipLink",
                 icon: "skip_next",
-                outlined: true,
-                statusBadges: ["new"]
+                outlined: true
             },
             {
                 title: "Slab",
@@ -237,15 +236,15 @@ module.exports = [
                 path: "/components/status",
                 componentPath: "components/Status",
                 icon: "check_circle",
-                outlined: true
+                outlined: true,
+                statusBadges: ["updated"]
             },
             {
                 title: "Tables",
                 path: "/components/tables",
                 componentPath: "components/Tables",
                 icon: "view_list",
-                outlined: true,
-                statusBadges: ["updated"]
+                outlined: true
             },
             {
                 title: "Tabs",
@@ -261,7 +260,7 @@ module.exports = [
                 componentPath: "components/CodeTags",
                 icon: "code",
                 outlined: true,
-                statusBadges: ["new"]
+                statusBadges: ["updated"]
             },
             {
                 title: "Toast",
@@ -276,8 +275,7 @@ module.exports = [
                 path: "/components/togglebox",
                 componentPath: "components/Togglebox",
                 icon: "toggle_off",
-                outlined: true,
-                statusBadges: ["updated"]
+                outlined: true
             },
             {
                 title: "Tooltips",
@@ -285,7 +283,7 @@ module.exports = [
                 componentPath: "components/Tooltips",
                 icon: "filter_frames",
                 outlined: true,
-                statusBadges: ["javascript", "updated"]
+                statusBadges: ["javascript"]
             },
             {
                 title: "Topbar",
@@ -293,7 +291,7 @@ module.exports = [
                 componentPath: "components/Topbar",
                 icon: "call_to_action",
                 outlined: true,
-                statusBadges: ["javascript", "updated"]
+                statusBadges: ["javascript"]
             }
         ]
     }

--- a/src/App/utils/RenderPage/__snapshots__/index.test.js.snap
+++ b/src/App/utils/RenderPage/__snapshots__/index.test.js.snap
@@ -13,7 +13,7 @@ exports[`Utilities: RenderPage renders 1`] = `
       className="dg-current-version text-uppercase"
     >
       Design Guide – v. 
-      10.3.0
+      10.4.0
     </span>
     <Switch>
       <Route
@@ -234,7 +234,6 @@ exports[`Utilities: RenderPage renders 1`] = `
               "path": "/components/checkbox",
               "statusBadges": Array [
                 "javascript",
-                "updated",
               ],
               "title": "Checkbox",
             },
@@ -354,7 +353,6 @@ exports[`Utilities: RenderPage renders 1`] = `
               "path": "/components/radio-button",
               "statusBadges": Array [
                 "javascript",
-                "updated",
               ],
               "title": "Radio button",
             },
@@ -365,7 +363,6 @@ exports[`Utilities: RenderPage renders 1`] = `
               "path": "/components/rangeslider",
               "statusBadges": Array [
                 "javascript",
-                "updated",
               ],
               "title": "Rangeslider",
             },
@@ -376,6 +373,7 @@ exports[`Utilities: RenderPage renders 1`] = `
               "path": "/components/sheet",
               "statusBadges": Array [
                 "javascript",
+                "updated",
               ],
               "title": "Sheet",
             },
@@ -386,7 +384,6 @@ exports[`Utilities: RenderPage renders 1`] = `
               "path": "/components/select",
               "statusBadges": Array [
                 "javascript",
-                "updated",
               ],
               "title": "Select",
             },
@@ -397,7 +394,6 @@ exports[`Utilities: RenderPage renders 1`] = `
               "path": "/components/sidebar",
               "statusBadges": Array [
                 "javascript",
-                "updated",
               ],
               "title": "Sidebar",
             },
@@ -406,9 +402,6 @@ exports[`Utilities: RenderPage renders 1`] = `
               "icon": "skip_next",
               "outlined": true,
               "path": "/components/skip-link",
-              "statusBadges": Array [
-                "new",
-              ],
               "title": "Skip link",
             },
             Object {
@@ -423,6 +416,9 @@ exports[`Utilities: RenderPage renders 1`] = `
               "icon": "check_circle",
               "outlined": true,
               "path": "/components/status",
+              "statusBadges": Array [
+                "updated",
+              ],
               "title": "Status",
             },
             Object {
@@ -430,9 +426,6 @@ exports[`Utilities: RenderPage renders 1`] = `
               "icon": "view_list",
               "outlined": true,
               "path": "/components/tables",
-              "statusBadges": Array [
-                "updated",
-              ],
               "title": "Tables",
             },
             Object {
@@ -451,7 +444,7 @@ exports[`Utilities: RenderPage renders 1`] = `
               "outlined": true,
               "path": "/components/tags",
               "statusBadges": Array [
-                "new",
+                "updated",
               ],
               "title": "Tags",
             },
@@ -470,9 +463,6 @@ exports[`Utilities: RenderPage renders 1`] = `
               "icon": "toggle_off",
               "outlined": true,
               "path": "/components/togglebox",
-              "statusBadges": Array [
-                "updated",
-              ],
               "title": "Togglebox",
             },
             Object {
@@ -482,7 +472,6 @@ exports[`Utilities: RenderPage renders 1`] = `
               "path": "/components/tooltips",
               "statusBadges": Array [
                 "javascript",
-                "updated",
               ],
               "title": "Tooltips",
             },
@@ -493,7 +482,6 @@ exports[`Utilities: RenderPage renders 1`] = `
               "path": "/components/topbar",
               "statusBadges": Array [
                 "javascript",
-                "updated",
               ],
               "title": "Topbar",
             },


### PR DESCRIPTION
# Changelog

## [10.4.0] - 25.10.2022

## Changed
- Error icons
    - Updated error icons to use “warning” icon instead
- Sheet component
    - Update z-index for sheet header
- Pagination component documentation
    - Showcasing compact version of pagination
- Pagination component
    - Update pagination.less to include .compact class for pagination styling as “mobile view”

## Added
- Codetags component
    - Added class for filter tag styling
- Dropdown component

## Bugfixes
- Input group
    - Readded postfix for input group elements
- Searchbox
    - Visual bug in mobile view fixed
- Sidebar
    - Added id for overview in Toast and Tables so it can appear in sidebar
    - Stop error messages to appear when secondary nav does not have any children
- Toast documentation page
    - Anchor linked to wrong page