### PR TITLE
Feature/style tabs active link element

### DIFF
--- a/src/App/ComponentsDocumentation/components/Tabs/__snapshots__/index.test.js.snap
+++ b/src/App/ComponentsDocumentation/components/Tabs/__snapshots__/index.test.js.snap
@@ -115,6 +115,32 @@ exports[`Components: Tabs DeveloperDocumentation renders 1`] = `
     />
      is the scrollable element.
   </p>
+  <h4>
+    🎨 Styling support for 
+    <CodeTags
+      code=".active"
+      type="secondary"
+    />
+     class
+  </h4>
+  <p>
+    The same styling will be applied whether the 
+    <CodeTags
+      code=".active"
+      type="secondary"
+    />
+     class is applied on the 
+    <CodeTags
+      code="<li>"
+      type="secondary"
+    />
+     element or the 
+    <CodeTags
+      code="<a>"
+      type="secondary"
+    />
+     element. This way it supports out of the box Nuxt router's behavior.
+  </p>
 </Fragment>
 `;
 

--- a/src/App/ComponentsDocumentation/components/Tabs/index.js
+++ b/src/App/ComponentsDocumentation/components/Tabs/index.js
@@ -64,6 +64,10 @@ const DeveloperDocumentation = () => (
         <p>
             Moves the scroll position of the tabs to the user specified position. The value to be passed to <CodeTags type="secondary" code="scrollState" /> is the object <CodeTags type="secondary" code="{ scrollStart, scrollTotalAmount }" />. <CodeTags type="secondary" code="scrollStart" /> is the current scroll position, <CodeTags type="secondary" code="scrollTotalAmount" /> is the amount to be scrolled from the current scroll position (negative values for left scroll, positive values for right scroll). Note: <CodeTags type="primary" code={"<ul>"} /> is the scrollable element.
         </p>
+        <h4>🎨 Styling support for <CodeTags type="secondary" code=".active" /> class</h4>
+        <p>
+            The same styling will be applied whether the <CodeTags type="secondary" code=".active" /> class is applied on the <CodeTags type="secondary" code="<li>" /> element or the <CodeTags type="secondary" code="<a>" /> element. This way it supports out of the box Nuxt router's behavior.
+        </p>
     </>
 );
 

--- a/src/less/components/payex/tabs.less
+++ b/src/less/components/payex/tabs.less
@@ -12,10 +12,9 @@
                 }
             }
 
-            &.active {
-                a {
-                    color: @brand-secondary;
-                }
+            &.active a,
+            a.active {
+                color: @brand-secondary;
             }
         }
     }

--- a/src/less/components/tabs.less
+++ b/src/less/components/tabs.less
@@ -92,12 +92,13 @@
 
             &.active {
                 padding-left: 0;
+            }
 
-                > a {
-                    color: @brand-secondary;
-                    position: relative;
-                    border-bottom: 2px solid @medium-brown;
-                }
+            &.active > a,
+            a.active {
+                color: @brand-secondary;
+                position: relative;
+                border-bottom: 2px solid @medium-brown;
             }
         }
     }


### PR DESCRIPTION
Ticket: https://payexjira.atlassian.net/browse/SWED-1976
🎨 styling support 

## Description
Offer better support for Nuxt (Vue) projects by adding an identical style for tabs with the `active` class name applied on the `<a>` element instead of on the `<li>` element (as it was now).

Now, `ul li.active > a` and `ul li a.active` have identical styling.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Review instructions
[Review instructions](../REVIEW_INSTRUCTIONS.md)