### PR TITLE
added icons for expandable and dropdown in component page

### DIFF
--- a/src/App/ComponentsDocumentation/components/Components/__snapshots__/index.test.js.snap
+++ b/src/App/ComponentsDocumentation/components/Components/__snapshots__/index.test.js.snap
@@ -313,12 +313,39 @@ exports[`Components: Components MenuOverview renders 1`] = `
         aria-hidden="true"
         className="material-icons material-icons-outlined mr-3"
       >
-        search
+        expand_more
       </i>
       <span
         className="h3 m-0"
       >
         Dropdown
+      </span>
+    </div>
+    <i
+      aria-hidden="true"
+      className="material-icons material-icons-outlined"
+    >
+      arrow_forward
+    </i>
+  </Link>
+  <Link
+    className="cards cards-primary cards-wide"
+    key="Expandable"
+    to="/components/expandable"
+  >
+    <div
+      className="cards-content flex-row align-items-center m-0 "
+    >
+      <i
+        aria-hidden="true"
+        className="material-icons mr-3"
+      >
+        expand
+      </i>
+      <span
+        className="h3 m-0"
+      >
+        Expandable
       </span>
     </div>
     <i

--- a/src/App/__snapshots__/index.test.js.snap
+++ b/src/App/__snapshots__/index.test.js.snap
@@ -265,7 +265,7 @@ exports[`Main: App renders 1`] = `
                     },
                     Object {
                       "componentPath": "components/Dropdown",
-                      "icon": "search",
+                      "icon": "expand_more",
                       "outlined": true,
                       "path": "/components/dropdown",
                       "statusBadges": Array [
@@ -276,6 +276,7 @@ exports[`Main: App renders 1`] = `
                     },
                     Object {
                       "componentPath": "components/Expandable",
+                      "icon": "expand",
                       "path": "/components/expandable",
                       "statusBadges": Array [
                         "javascript",

--- a/src/App/routes/components.js
+++ b/src/App/routes/components.js
@@ -104,7 +104,7 @@ module.exports = [
                 title: "Dropdown",
                 path: "/components/dropdown",
                 componentPath: "components/Dropdown",
-                icon: "search",
+                icon: "expand_more",
                 outlined: true,
                 statusBadges: ["javascript", "new"]
             },
@@ -112,6 +112,7 @@ module.exports = [
                 title: "Expandable",
                 path: "/components/expandable",
                 componentPath: "components/Expandable",
+                icon: "expand",
                 statusBadges: ["javascript"]
             },
             {

--- a/src/App/utils/RenderPage/__snapshots__/index.test.js.snap
+++ b/src/App/utils/RenderPage/__snapshots__/index.test.js.snap
@@ -259,7 +259,7 @@ exports[`Utilities: RenderPage renders 1`] = `
             },
             Object {
               "componentPath": "components/Dropdown",
-              "icon": "search",
+              "icon": "expand_more",
               "outlined": true,
               "path": "/components/dropdown",
               "statusBadges": Array [
@@ -270,6 +270,7 @@ exports[`Utilities: RenderPage renders 1`] = `
             },
             Object {
               "componentPath": "components/Expandable",
+              "icon": "expand",
               "path": "/components/expandable",
               "statusBadges": Array [
                 "javascript",


### PR DESCRIPTION
## Description
- Expandable was not showing up because it was missing the icon variable in src\App\routes\components.js
- updated dropdown icon
- updated snapshots

## Motivation and Context
https://payexjira.atlassian.net/browse/SWED-1966

Expandable component was ONLY showing up in the sidebar.

## How Has This Been Tested?
Ran all tests.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/60387086/203515206-962f8e44-5a1e-450a-ac36-378913cc7c72.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Review instructions
[Review instructions](../REVIEW_INSTRUCTIONS.md)