### PR TITLE
Release 10.5.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,20 +1,43 @@
 # Changelog
 
-## [10.4.1] - 04.11.2022
+## [10.5.0] - 06.12.2022
 
 ## Changed
--   Dropdown component
-    -   📐 Fix weird border behavior to avoid shifting sibling elements
-    -   🧹 Remove css button style dependency
-    -   ✏ Rename ".btn-elem" class name to ".dropdown-option". Use this class to style buttons inside the dropdown menu
+-   Slab component:
+    -   Changes to the design. Shadows are reworked. Changed slab arrow to a clip-path. Removed colors from examples.
+
+-   Z-index:
+    -   Moved variables to global to get a better overview. Updated all values so stacking works correctly.
+
+-   A11y:
+    -   Made element focus on keyboard navigation more visible and improved consistency between Chromium and non-chromium browsers.
+    -   Updated components to better work with high contrast mode on the user's OS. 
+
+-   Documentation:
+    -   Updated some component documentation: Badge, Radio button, Button and Slab
 
 ## Added
--   Tabs component
-    -   🎨 Added styling support for active class on anchor tag for Nuxt router support
+-   Icon only Button:
+    -   Added a new button variant with only an icon. 
+
+-   Radio button:
+    -   Added a new radio button style. It looks like a normal button, but with radio functionality. 
+
+-   Badges:
+    -   Added a lot more color variants to badges.
+
+-   Latest version:
+    -   Added a banner on the home page that redirects to the latest version of the DG. Also added a link on the top of the component page.
 
 ## Bugfixes
--   Copywrite section
-    -   ✒ Duplicate subsection: "Simple and guiding" and "Positive voice" was the same
+-   Button:
+    -   Fixed pixel pushing on click.
 
--   Links in homepage changelog
-    -   🔗 Fix dead links
+-   Documentation page:
+    -   Component overview:
+        -   Fixed expandable component not appearing in the main overview.
+        -   Added icons for expandable and dropdown.
+    -   Sheet component:
+        -   In the Sheet demo: renamed the buttons and modified the actions. 
+    -   Search scroll bar:
+        -   Fixed the scroll bar to only show when needed. Removed bottom scroll bar.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swedbankpay/design-guide",
-  "version": "10.4.1",
+  "version": "10.5.0",
   "description": "Swedbank Pay Design Guide",
   "main": "src/scripts/main/index.js",
   "scripts": {

--- a/src/App/Home/constants.js
+++ b/src/App/Home/constants.js
@@ -4,10 +4,18 @@ const basename = process.env.basename;
 
 export const changeLogs = [
     {
+        version: "10.5.0",
+        title: "Experis' Christmas gift",
+        text: <p>This is an early christmas present🎁 for you guys! A new release✨! Some components received some freshness. The button components got some new styles, The slab component got reworked - The shadows should look better now, and the badge component got more ✨colorful✨💅. We have also made a lot of accessibility upgrades. Especially regarding high contrast and focus on elements.
+        Bugs🐛 were squashed! The expandable component tried to take an early christmas vacation and disappeared from the component overview. It was quickly caught and returned to component jail🚨. We also removed a scrollbar from the search results because two bars does not make you scroll faster.😔 Have you casually been using an old version all along? Don&apos;t worry! With this new update we have added a link besides the version number to take you there directly✈.
+        The button has been bullying its surrounding pixels. After a stern talk it agreed to stop pushing them around. Talk about personal growth! 🏅
+        That&apos;s it for now! Hope you have a great holiday!🎅🎄🤶</p>,
+        latestVersion: true
+    },
+    {
         version: "10.4.1",
         title: "Hotfixes incoming 🚤",
-        text: "Here is a release solely based on feedback from our users 🤝 Turns out the dropdown component wasn’t perfect after all, and it had some weird alignment behavior when placed side-by-side with other components. This is now taken care of. We also renamed the class used to style the buttons inside the dropdown menu from '.btn-elem' to '.dropdown-option'. In addition, we removed the css dependency from the button component, so it is now independent. You can now use it as you want without having to import the button styles. We also added style support for the tabs component. Now the <a> element can also have the class of active instead of the <li> and the correct style will be applied. This to ensure an out of the box support for Nuxt router. Enjoy 😊",
-        latestVersion: true
+        text: "Here is a release solely based on feedback from our users 🤝 Turns out the dropdown component wasn’t perfect after all, and it had some weird alignment behavior when placed side-by-side with other components. This is now taken care of. We also renamed the class used to style the buttons inside the dropdown menu from '.btn-elem' to '.dropdown-option'. In addition, we removed the css dependency from the button component, so it is now independent. You can now use it as you want without having to import the button styles. We also added style support for the tabs component. Now the <a> element can also have the class of active instead of the <li> and the correct style will be applied. This to ensure an out of the box support for Nuxt router. Enjoy 😊"
     },
     {
         version: "10.4.0",

--- a/src/App/routes/components.js
+++ b/src/App/routes/components.js
@@ -45,7 +45,8 @@ module.exports = [
                 path: "/components/badge",
                 componentPath: "components/Badge",
                 icon: "more",
-                outlined: true
+                outlined: true,
+                statusBadges: ["updated"]
             },
             {
                 title: "Breadcrumb",
@@ -59,7 +60,8 @@ module.exports = [
                 path: "/components/buttons",
                 componentPath: "components/Buttons",
                 icon: "touch_app",
-                outlined: true
+                outlined: true,
+                statusBadges: ["updated"]
             },
             {
                 title: "Cards",
@@ -106,7 +108,7 @@ module.exports = [
                 componentPath: "components/Dropdown",
                 icon: "expand_more",
                 outlined: true,
-                statusBadges: ["javascript", "new"]
+                statusBadges: ["javascript"]
             },
             {
                 title: "Expandable",
@@ -120,7 +122,7 @@ module.exports = [
                 path: "/components/input-field",
                 componentPath: "components/InputField",
                 icon: "text_fields",
-                statusBadges: ["javascript", "updated"]
+                statusBadges: ["javascript"]
             },
             {
                 title: "Links",
@@ -184,7 +186,7 @@ module.exports = [
                 path: "/components/radio-button",
                 componentPath: "components/RadioButton",
                 icon: "radio_button_checked",
-                statusBadges: ["javascript"]
+                statusBadges: ["javascript", "updated"]
             },
             {
                 title: "Rangeslider",
@@ -200,7 +202,7 @@ module.exports = [
                 componentPath: "components/Sheet",
                 icon: "vertical_split",
                 outlined: true,
-                statusBadges: ["javascript", "updated"]
+                statusBadges: ["javascript"]
             },
             {
                 title: "Select",
@@ -230,15 +232,15 @@ module.exports = [
                 path: "/components/slab",
                 componentPath: "components/Slab",
                 icon: "crop_landscape",
-                outlined: true
+                outlined: true,
+                statusBadges: ["updated"]
             },
             {
                 title: "Status",
                 path: "/components/status",
                 componentPath: "components/Status",
                 icon: "check_circle",
-                outlined: true,
-                statusBadges: ["updated"]
+                outlined: true
             },
             {
                 title: "Tables",
@@ -253,15 +255,14 @@ module.exports = [
                 componentPath: "components/Tabs",
                 icon: "folder",
                 outlined: true,
-                statusBadges: ["javascript", "updated"]
+                statusBadges: ["javascript"]
             },
             {
                 title: "Tags",
                 path: "/components/tags",
                 componentPath: "components/CodeTags",
                 icon: "code",
-                outlined: true,
-                statusBadges: ["updated"]
+                outlined: true
             },
             {
                 title: "Toast",


### PR DESCRIPTION
# Changelog

## [10.5.0] - 06.12.2022

## Changed
-   Slab component:
    -   Changes to the design. Shadows are reworked. Changed slab arrow to a clip-path. Removed colors from examples.

-   Z-index:
    -   Moved variables to global to get a better overview. Updated all values so stacking works correctly.

-   A11y:
    -   Made element focus on keyboard navigation more visible and improved consistency between Chromium and non-chromium browsers.
    -   Updated components to better work with high contrast mode on the user's OS. 

-   Documentation:
    -   Updated some component documentation: Badge, Radio button, Button and Slab

## Added
-   Icon only Button:
    -   Added a new button variant with only an icon. 

-   Radio button:
    -   Added a new radio button style. It looks like a normal button, but with radio functionality. 

-   Badges:
    -   Added a lot more color variants to badges.

-   Latest version:
    -   Added a banner on the home page that redirects to the latest version of the DG. Also added a link on the top of the component page.

## Bugfixes
-   Button:
    -   Fixed pixel pushing on click.

-   Documentation page:
    -   Component overview:
        -   Fixed expandable component not appearing in the main overview.
        -   Added icons for expandable and dropdown.
    -   Sheet component:
        -   In the Sheet demo: renamed the buttons and modified the actions. 
    -   Search scroll bar:
        -   Fixed the scroll bar to only show when needed. Removed bottom scroll bar.
