### PR TITLE
SWED-2045 fix z-index tooltip & border input addon

### DIFF
--- a/src/less/components/form.less
+++ b/src/less/components/form.less
@@ -220,6 +220,7 @@ legend {
     border-bottom-color: @medium-brown;
     border-radius: 2px 2px 0 0;
     box-shadow: none;
+
     .form-control-focus(@brand-secondary);
     .placeholder(@brand-secondary-light-2);
 
@@ -289,6 +290,10 @@ legend {
     }
 
     margin-bottom: @base-margin-lg;
+
+    .input-group .form-control:not(:last-child) {
+        border-right: none;
+    }
 
     .form-control:focus-within {
         outline: 2px auto @brand-secondary;

--- a/src/less/components/input-group.less
+++ b/src/less/components/input-group.less
@@ -85,14 +85,6 @@
             border-left: none;
         }
 
-        &:first-child {
-            margin-right: -1px;
-        }
-
-        &:last-child {
-            margin-left: -1px;
-        }
-
         input[type="radio"],
         input[type="checkbox"] {
             margin-top: 0;

--- a/src/less/components/tooltip.less
+++ b/src/less/components/tooltip.less
@@ -26,6 +26,7 @@
         border-color: rgba(255, 255, 255, 1) transparent transparent transparent;
         opacity: 0;
         transition: opacity 0.3s ease-in-out;
+        z-index: calc(@tooltip-z-index + 1);
     }
 
     [role="tooltip"] {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->


From slack message from Henrik: https://payex.slack.com/archives/C0L3W8B2S/p1670411896336969
Appeared the removal of z-index in some places created issues.

Issues indentified:
- tooltip arrow disappeared
- input border when the postfix is used

It got fixed by bringing back the z-index on the tooltip :before arrow, making it a dynamic value again (calculating the z-tooltip index variable value + 1)
And for the input we removed the z-index + margins "hack" and solve it by removing border right when input is followed by another element.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

TEST:

tooltip:

tooltip arrow should be displayed

input:

there should be no border between postfix and the input

(BTW even before that release it seems like on error state there was the border displayed)

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have updated the **CHANGELOG** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Review instructions
[Review instructions](../REVIEW_INSTRUCTIONS.md)