### PR TITLE
Release 10.5.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,40 +1,14 @@
 # Changelog
 
-## [10.5.0] - 06.12.2022
+## [10.5.1] - 09.12.2022
 
 ## Changed
--   Slab component:
-    -   Changes to the design. Shadows are reworked. Changed slab arrow to a clip-path. Removed colors from examples.
-
--   Z-index:
-    -   Moved variables to global to get a better overview. Updated all values so stacking works correctly.
-
--   A11y:
-    -   Made element focus on keyboard navigation more visible and improved consistency between Chromium and non-chromium browsers.
-    -   Updated components to better work with high contrast mode on the user's OS. 
-
--   Documentation:
-    -   Updated some component documentation: Badge, Radio button, Button and Slab
-
-## Added
--   Icon only Button:
-    -   Added a new button variant with only an icon. 
-
--   Radio button:
-    -   Added a new radio button style. It looks like a normal button, but with radio functionality. 
-
--   Badges:
-    -   Added a lot more color variants to badges.
+-   Tooltip component:
+    -   The only component that was still dependent on another component's style. Added styles to the tooltip.less file, so it is independent. This is *kind of* a breaking change, but not really since the old version still works, but if you want to keep up2date, delete `.btn` and `.btn-link` classes.
 
 ## Bugfixes
--   Button:
-    -   Fixed pixel pushing on click.
+-   Tooltip component:
+    -   Z-index changes from v/10.5.0 removed the belonging arrow between the tooltip icon and the tooltip.
 
--   Documentation page:
-    -   Component overview:
-        -   Fixed expandable component not appearing in the main overview.
-        -   Added icons for expandable and dropdown.
-    -   Sheet component:
-        -   In the Sheet demo: renamed the buttons and modified the actions. 
-    -   Search scroll bar:
-        -   Fixed the scroll bar to only show when needed. Removed bottom scroll bar.
+-   Input field component: 
+    -   Had some issues with borders when postfix was displayed. This is now fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swedbankpay/design-guide",
-  "version": "10.5.0",
+  "version": "10.5.1",
   "description": "Swedbank Pay Design Guide",
   "main": "src/scripts/main/index.js",
   "scripts": {

--- a/src/App/Home/constants.js
+++ b/src/App/Home/constants.js
@@ -1,16 +1,22 @@
 import React from "react";
+import CodeTags from "@components/CodeTags";
 
 const basename = process.env.basename;
 
 export const changeLogs = [
     {
         version: "10.5.0",
+        title: "A quick and clean hotfix incoming!",
+        text: <p>Small bugs were located post producing last version. These are now fixed! The tooltip component was before dependent on button&apos;s .less file. Not anymore! Be aware! This is kind of, not really, a breaking change, meaning your old code will still work, but you need to delete <CodeTags type="secondary" code=".btn"/> and <CodeTags type="secondary" code=".btn-link"/> classes in your tooltip component to be fully up2d8. In addition, we added back the arrow pointing up to the tooltip that are appearing, and removed the annoying border in input fields if you add postfix to it. That&apos;s all folks! Have a merry Christmas! 🎅🏼🎅🏼</p>,
+        latestVersion: true
+    },
+    {
+        version: "10.5.0",
         title: "Experis' Christmas gift",
         text: <p>This is an early christmas present🎁 for you guys! A new release✨! Some components received some freshness. The button components got some new styles, The slab component got reworked - The shadows should look better now, and the badge component got more ✨colorful✨💅 We have also made a lot of accessibility upgrades. Especially regarding high contrast and focus on elements.
         Bugs🐛 were squashed! The expandable component tried to take an early christmas vacation and disappeared from the component overview. It was quickly caught and returned to component jail🚨 We also removed a scrollbar from the search results because two bars does not make you scroll faster 😔
         The button has been bullying its surrounding pixels. After a stern talk it agreed to stop pushing them around. Talk about personal growth! 🏅
-        That&apos;s it for now! Hope you have a great holiday!🎅🎄🤶</p>,
-        latestVersion: true
+        That&apos;s it for now! Hope you have a great holiday!🎅🎄🤶</p>
     },
     {
         version: "10.4.1",

--- a/src/App/__snapshots__/index.test.js.snap
+++ b/src/App/__snapshots__/index.test.js.snap
@@ -480,6 +480,7 @@ exports[`Main: App renders 1`] = `
                       "path": "/components/tooltips",
                       "statusBadges": Array [
                         "javascript",
+                        "updated",
                       ],
                       "title": "Tooltips",
                     },

--- a/src/App/routes/components.js
+++ b/src/App/routes/components.js
@@ -285,7 +285,7 @@ module.exports = [
                 componentPath: "components/Tooltips",
                 icon: "filter_frames",
                 outlined: true,
-                statusBadges: ["javascript"]
+                statusBadges: ["javascript", "updated"]
             },
             {
                 title: "Topbar",

--- a/src/App/utils/RenderPage/__snapshots__/index.test.js.snap
+++ b/src/App/utils/RenderPage/__snapshots__/index.test.js.snap
@@ -13,7 +13,7 @@ exports[`Utilities: RenderPage renders 1`] = `
       className="dg-current-version text-uppercase"
     >
       Design Guide – v. 
-      10.5.0
+      10.5.1
     </span>
     <Switch>
       <Route
@@ -474,6 +474,7 @@ exports[`Utilities: RenderPage renders 1`] = `
               "path": "/components/tooltips",
               "statusBadges": Array [
                 "javascript",
+                "updated",
               ],
               "title": "Tooltips",
             },


### PR DESCRIPTION
# Changelog

## [10.5.1] - 09.12.2022

## Changed
-   Tooltip component:
    -   The only component that was still dependent on another component's style. Added styles to the tooltip.less file, so it is independent. This is *kind of* a breaking change, but not really since the old version still works, but if you want to keep up2date, delete `.btn` and `.btn-link` classes.

## Bugfixes
-   Tooltip component:
    -   Z-index changes from v/10.5.0 removed the belonging arrow between the tooltip icon and the tooltip.

-   Input field component: 
    -   Had some issues with borders when postfix was displayed. This is now fixed
