### PR TITLE
Release 10.7.4

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,8 +1,11 @@
 # Changelog
 
-## [10.7.3] - 07.03.2023
+## [10.7.4] - 14.03.2023
 
 ## Component changes
--   Sidebar
-    -   Webkit-scroll appearances
-    -   Bugfix done for Developer Portal
+-   None
+
+## Design Guide documentation changes
+-   Testing
+    -   Change test provider from Enzyme to React Testing Library (RTL).
+    -   These changes are purely maintenance - a part of migrating to React 18.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swedbankpay/design-guide",
-  "version": "10.7.3",
+  "version": "10.7.4",
   "description": "Swedbank Pay Design Guide",
   "main": "src/scripts/main/index.js",
   "scripts": {

--- a/src/App/ComponentsDocumentation/__snapshots__/index.test.js.snap
+++ b/src/App/ComponentsDocumentation/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`ComponentsDocumentation: index renders 1`] = `
     className="dg-current-version text-uppercase"
   >
     Design Guide – v. 
-    10.7.3
+    10.7.4
   </span>
 </div>
 `;

--- a/src/App/Home/constants.js
+++ b/src/App/Home/constants.js
@@ -5,6 +5,11 @@ const basename = process.env.basename;
 
 export const changeLogs = [
     {
+        version: "10.7.4",
+        title: "Doing the groundwork for a brighter future.",
+        text: "Purely DG page maintenance; migrated tests from using Enzyme to React Testing Library. A big step into the direction of migrating to React 18."
+    },
+    {
         version: "10.7.3",
         title: "Minor scrollbar changes for sidebar",
         text: "Bugfix for Developer Portal"

--- a/src/App/Identity/__snapshots__/index.test.js.snap
+++ b/src/App/Identity/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`Core: index renders 1`] = `
     className="dg-current-version text-uppercase"
   >
     Design Guide – v. 
-    10.7.3
+    10.7.4
   </span>
 </div>
 `;

--- a/src/App/Patterns/__snapshots__/index.test.js.snap
+++ b/src/App/Patterns/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`Patterns: index renders 1`] = `
     className="dg-current-version text-uppercase"
   >
     Design Guide – v. 
-    10.7.3
+    10.7.4
   </span>
 </div>
 `;

--- a/src/App/Utilities/__snapshots__/index.test.js.snap
+++ b/src/App/Utilities/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`Utilities: index renders 1`] = `
     className="dg-current-version text-uppercase"
   >
     Design Guide - v. 
-    10.7.3
+    10.7.4
   </span>
   <div
     className="d-flex align-items-center"


### PR DESCRIPTION
# Changelog

## [10.7.4] - 14.03.2023

## Component changes
-   None

## Design Guide documentation changes
-   Testing
    -   Change test provider from Enzyme to React Testing Library (RTL).
    -   These changes are purely maintenance - a part of migrating to React 18.
