### PR TITLE
RELEASE 10.8.1 - preparation

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,13 @@ Before merging to master to create a release, make sure you follow these steps:
 - Pull latest changes.
 - Create a release branch where the name is the new tag. (`release/x.x.x`)
 - Update the version in `~/package.json`.
+  - then run `npm i` to also update package-lock
+  - run `npx browserslist@latest --update-db` to update browserslist
 - Make sure the `RELEASE_NOTES.md` is correct (date and version) and only contains- changes for the current release.
 - Update the changelog constants on the Home page ( "src\App\Home\constants.js" ).
 - Update statusBadges in routes.
 - Commit the changes and create a pull request from `release/x.x.x` branch to `master` and `develop`.
+  - use the release-notes as PR description
 - When approved, rename the merge commit to `Release x.x.x` and merge.
 - Change branch to `master`.
 - Pull latest changes.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [10.8.1] - 20.04.2023
+## [10.8.1] - 24.04.2023
 
 ## Component changes
 
@@ -17,6 +17,9 @@
     -   Removed all references to button-link (now users should use tertiary)
     -   Removed all references to input textx "hint text expander"
     -   PayEx restore destructive buttons Preview block in docs (but beware, this chunk will probably not be updated in the future)
+
+-   Sheet
+    -   Close button size class got fixed
 
 -   Forms (in Patterns & Login)
     -   Add autocomplete attributes to all relevant inputs code snippets to enforce good practices

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@swedbankpay/design-guide",
-  "version": "10.8.0",
+  "version": "10.8.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@swedbankpay/design-guide",
-      "version": "10.8.0",
+      "version": "10.8.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -5691,9 +5691,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001469",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001469.tgz",
-      "integrity": "sha512-Rcp7221ScNqQPP3W+lVOYDyjdR6dC+neEQCttoNr5bAyz54AboB4iwpnWgyi8P4YUsPybVzT4LgWiBbI3drL4g==",
+      "version": "1.0.30001481",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001481.tgz",
+      "integrity": "sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==",
       "dev": true,
       "funding": [
         {
@@ -5703,6 +5703,10 @@
         {
           "type": "tidelift",
           "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
         }
       ]
     },
@@ -22036,9 +22040,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30001469",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001469.tgz",
-      "integrity": "sha512-Rcp7221ScNqQPP3W+lVOYDyjdR6dC+neEQCttoNr5bAyz54AboB4iwpnWgyi8P4YUsPybVzT4LgWiBbI3drL4g==",
+      "version": "1.0.30001481",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001481.tgz",
+      "integrity": "sha512-KCqHwRnaa1InZBtqXzP98LPg0ajCVujMKjqKDhZEthIpAsJl/YEIa3YvXjGXPVqzZVguccuu7ga9KOE1J9rKPQ==",
       "dev": true
     },
     "chalk": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@swedbankpay/design-guide",
-  "version": "10.8.0",
+  "version": "10.8.1",
   "description": "Swedbank Pay Design Guide",
   "main": "src/scripts/main/index.js",
   "scripts": {

--- a/src/App/ComponentsDocumentation/__snapshots__/index.test.js.snap
+++ b/src/App/ComponentsDocumentation/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`ComponentsDocumentation: index renders 1`] = `
     className="dg-current-version text-uppercase"
   >
     Design Guide – v. 
-    10.8.0
+    10.8.1
   </span>
 </div>
 `;

--- a/src/App/Home/constants.js
+++ b/src/App/Home/constants.js
@@ -5,6 +5,15 @@ const basename = process.env.basename;
 
 export const changeLogs = [
     {
+        version: "10.8.1",
+        title: "Iteration patch, minor fixes",
+        text: <p>Spring has arrived, and it&apos;s time to tidy up the small mess we left behind in our previous release 🧹.
+            <br/>We&apos;ve made a few minor UI fixes in the text inputs 🩹 and addressed some obsolete content that had slipped our minds while updating the documentation 🚮.
+            <br/>We&apos;ve revived the documentation about the destructive buttons for our PayEx comrades 📝 (style was silently suppported, but silent is not our thing 🥳).
+            <br/>To add some extra pizzazz, we&apos;ve also included autocomplete functionality in our forms examples by utilizing the autocomplete attributes. Let&apos;s make our final user&apos;s experience as enjoyable as possible by removing all possible friction 🚀🌟.
+            <br/>Lastly, we&apos;ve carried out some routine maintenance by updating some of our packages. 📦</p>
+    },
+    {
         version: "10.8.0",
         title: "A new beginning 🌅",
         text: <p>This one is a bittersweet release.

--- a/src/App/Identity/__snapshots__/index.test.js.snap
+++ b/src/App/Identity/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`Core: index renders 1`] = `
     className="dg-current-version text-uppercase"
   >
     Design Guide – v. 
-    10.8.0
+    10.8.1
   </span>
 </div>
 `;

--- a/src/App/Patterns/__snapshots__/index.test.js.snap
+++ b/src/App/Patterns/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`Patterns: index renders 1`] = `
     className="dg-current-version text-uppercase"
   >
     Design Guide – v. 
-    10.8.0
+    10.8.1
   </span>
 </div>
 `;

--- a/src/App/Utilities/__snapshots__/index.test.js.snap
+++ b/src/App/Utilities/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`Utilities: index renders 1`] = `
     className="dg-current-version text-uppercase"
   >
     Design Guide - v. 
-    10.8.0
+    10.8.1
   </span>
   <div
     className="d-flex align-items-center"


### PR DESCRIPTION
# Changelog

## [10.8.1] - 24.04.2023

## Component changes

-   Input text &amp; textarea fields
    -   fix Layout shift when focus-within
    -   fix border color around prefix on success state
-   Buttons
    -   fix colors PayEx destructive buttons when disabled

-   We continue on our migration to CSS Custom Properties

## Design Guide documentation changes
-   Button documentation &amp; Input field documentation
    -   Removed all references to button-link (now users should use tertiary)
    -   Removed all references to input textx "hint text expander"
    -   PayEx restore destructive buttons Preview block in docs (but beware, this chunk will probably not be updated in the future)

-   Sheet
    -   Close button size class got fixed

-   Forms (in Patterns & Login)
    -   Add autocomplete attributes to all relevant inputs code snippets to enforce good practices

## Deleted features
-   Expanding hint text script is removed

## Packages maintenance

-   bump Stylelint from 13 to 15
-   bump Codecov-action from 3.1.2 to 3.1.3
-   bump npm-publish from 1 to 2