### PR TITLE
SWED-2232 border-radius dialog

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,8 +4,12 @@
 
 ## Component changes
 
+### Non breaking UI changes
+
 - Typography
   - increase font-sizes & line-height of headers
+- Dialog
+  - add border-radius to the Dialog component
 
 ## Design Guide documentation changes
 

--- a/src/less/components/dialog.less
+++ b/src/less/components/dialog.less
@@ -25,6 +25,7 @@
 			align-items: center;
 			background: @white;
 			border-bottom: @dialog-border;
+			border-radius: 20px 20px 0 0;
 
 			/* stylelint-disable selector-list-comma-newline-after */
 			h1,
@@ -97,6 +98,7 @@
 			margin: 0;
 			display: flex;
 			justify-content: flex-end;
+			border-radius: 0 0 20px 20px;
 
 			> * {
 				margin: 0 0.25rem;

--- a/src/less/global.less
+++ b/src/less/global.less
@@ -170,6 +170,9 @@
 		var(--border-width-focus, 2px) - var(--border-width, 1px)
 	);
 
+	// Border radius
+	--border-radius-modal: 20px;
+
 	/**
 	*Z-indexes
 	*/


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
https://payexjira.atlassian.net/browse/SWED-2232
add border-radius to the dialog component
create a new CSS variable for it
not sure yet how we should name those border-radius variable in the future: an absolute scale (`border-radius-md`,`border-radius-lg`, etc ), or just per-use like we did for `z-index` (e.g. `border-radius-dialog`) . So far I chose the latter, because border-radius are not an easy thing to pick so better rely on the designer. But I'm not strongly convinced of my choice so far.
Anyway, until we make the CSS variable "API" open publicly we can modify this whenever we want.

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

### Before

![image](https://github.com/SwedbankPay/design.swedbankpay.com/assets/15030804/b9fb8802-1a64-4339-aeb0-23a1f94d0256)

### After

![image](https://github.com/SwedbankPay/design.swedbankpay.com/assets/15030804/7a4fcb93-04ac-407a-be9b-184d37f74797)

### Figma

![Untitled](https://github.com/SwedbankPay/design.swedbankpay.com/assets/15030804/cd62a118-0665-46c7-a0ec-8ce787b0ae81)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [x] I have updated the **CHANGELOG** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Review instructions

[Review instructions](../REVIEW_INSTRUCTIONS.md)
