### PR TITLE
feature/SWED-2268 expandable component preview

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -15,3 +15,5 @@
 - E2E tests for dropdown component
 
 ## Design System website
+
+- expand components preview containers to full screen

--- a/src/App/ComponentsDocumentation/components/Topbar/index.js
+++ b/src/App/ComponentsDocumentation/components/Topbar/index.js
@@ -44,6 +44,7 @@ const Overview = () => (
 			showCasePanel
 			codeFigure
 			showCasePanelAdvanced={topbarShowcase}
+			showExpandPreview={true}
 		/>
 		<h3>When to consider something else</h3>
 		<ul className="list list-bullet">

--- a/src/App/docutils/ComponentPreview/index.js
+++ b/src/App/docutils/ComponentPreview/index.js
@@ -214,6 +214,7 @@ const ComponentPreview = ({
 					.activeOptions
 					? [...this.props.showCasePanelAdvanced.elements[0].activeOptions]
 					: [],
+				previewExpanded: false,
 			};
 		}
 
@@ -351,6 +352,14 @@ const ComponentPreview = ({
 			}
 		}
 
+		setExpandedPreview(state) {
+			this.setState({ previewExpanded: state });
+
+			if (state) {
+				document.body.classList.add("has-vscroll");
+			}
+		}
+
 		render() {
 			return (
 				<>
@@ -358,13 +367,43 @@ const ComponentPreview = ({
 						id={this.props.showCasePanelAdvanced.id}
 						className={`showcase-panel showcase-panel-advanced${
 							this.state.optionsOpen ? " options-active" : ""
-						}${this.state.hideOptions ? " hide-options" : ""}`}
+						}${this.state.hideOptions ? " hide-options" : ""}
+						${this.state.previewExpanded ? " preview-expanded" : ""}`}
 					>
 						<div
 							id={this.props.showCasePanelAdvanced.tabsId}
 							className="tabs tabs-scroll"
 						>
 							<ul id={`${this.props.showCasePanelAdvanced.tabsId}-ul`}>
+								{!this.state.previewExpanded ? (
+									<button
+										className="btn btn-icon btn-xs"
+										type="button"
+										aria-label="Expand the preview container to full screen"
+										onClick={() => this.setExpandedPreview(true)}
+									>
+										<i
+											className="material-icons material-icons-outlined"
+											aria-hidden="true"
+										>
+											open_in_full
+										</i>
+									</button>
+								) : (
+									<button
+										className="btn btn-icon btn-xs"
+										type="button"
+										aria-label="Zoom out"
+										onClick={() => this.setExpandedPreview(false)}
+									>
+										<i
+											className="material-icons material-icons-outlined"
+											aria-hidden="true"
+										>
+											close_fullscreen
+										</i>
+									</button>
+								)}
 								{this.props.showCasePanelAdvanced.elements.map((element, i) => (
 									<li
 										key={i}

--- a/src/App/docutils/ComponentPreview/index.js
+++ b/src/App/docutils/ComponentPreview/index.js
@@ -19,6 +19,7 @@ const ComponentPreview = ({
 	codeFigure,
 	dangerousHTML,
 	negative,
+	showExpandPreview = false,
 }) => {
 	const _removeOuterTag = (element) => {
 		const div = document.createElement("div");
@@ -354,10 +355,9 @@ const ComponentPreview = ({
 
 		setExpandedPreview(state) {
 			this.setState({ previewExpanded: state });
-
-			if (state) {
-				document.body.classList.add("has-vscroll");
-			}
+			state
+				? document.body.classList.add("has-vscroll")
+				: document.body.classList.remove("has-vscroll");
 		}
 
 		render() {
@@ -375,35 +375,36 @@ const ComponentPreview = ({
 							className="tabs tabs-scroll"
 						>
 							<ul id={`${this.props.showCasePanelAdvanced.tabsId}-ul`}>
-								{!this.state.previewExpanded ? (
-									<button
-										className="btn btn-icon btn-xs"
-										type="button"
-										aria-label="Expand the preview container to full screen"
-										onClick={() => this.setExpandedPreview(true)}
-									>
-										<i
-											className="material-icons material-icons-outlined"
-											aria-hidden="true"
+								{this.props.showExpandPreview &&
+									(!this.state.previewExpanded ? (
+										<button
+											className="btn btn-icon btn-xs"
+											type="button"
+											aria-label="Expand the preview container to full screen"
+											onClick={() => this.setExpandedPreview(true)}
 										>
-											open_in_full
-										</i>
-									</button>
-								) : (
-									<button
-										className="btn btn-icon btn-xs"
-										type="button"
-										aria-label="Zoom out"
-										onClick={() => this.setExpandedPreview(false)}
-									>
-										<i
-											className="material-icons material-icons-outlined"
-											aria-hidden="true"
+											<i
+												className="material-icons material-icons-outlined"
+												aria-hidden="true"
+											>
+												open_in_full
+											</i>
+										</button>
+									) : (
+										<button
+											className="btn btn-icon btn-xs"
+											type="button"
+											aria-label="Zoom out"
+											onClick={() => this.setExpandedPreview(false)}
 										>
-											close_fullscreen
-										</i>
-									</button>
-								)}
+											<i
+												className="material-icons material-icons-outlined"
+												aria-hidden="true"
+											>
+												close_fullscreen
+											</i>
+										</button>
+									))}
 								{this.props.showCasePanelAdvanced.elements.map((element, i) => (
 									<li
 										key={i}
@@ -622,6 +623,7 @@ const ComponentPreview = ({
 				showCasePanelAdvanced ? (
 					<ShowCasePanelAdvanced
 						showCasePanelAdvanced={showCasePanelAdvanced}
+						showExpandPreview={showExpandPreview}
 					/>
 				) : (
 					<ShowCasePanel />
@@ -647,6 +649,7 @@ ComponentPreview.propTypes = {
 	codeFigure: PropTypes.bool,
 	dangerousHTML: PropTypes.bool,
 	negative: PropTypes.bool,
+	showExpandPreview: PropTypes.bool,
 };
 
 export default ComponentPreview;

--- a/src/less/documentation-swedbankpay.less
+++ b/src/less/documentation-swedbankpay.less
@@ -949,6 +949,13 @@
 								border-color: transparent;
 							}
 						}
+
+						> button[aria-label^="Expand"],
+						> button[aria-label^="Zoom"] {
+							width: 30px;
+							height: 30px;
+							margin: 4px;
+						}
 					}
 
 					.options-open {

--- a/src/less/documentation-swedbankpay.less
+++ b/src/less/documentation-swedbankpay.less
@@ -2,6 +2,8 @@
 @import "global.less";
 
 #designguide {
+	--fullscreen-z-index: 10000;
+
 	display: flex;
 	flex-direction: column;
 	min-height: 100%;
@@ -1073,6 +1075,16 @@
 					display: none;
 				}
 			}
+		}
+
+		&.preview-expanded {
+			position: fixed;
+			width: 100vw;
+			left: 0;
+			z-index: var(--fullscreen-z-index, 10000);
+			top: 0;
+			height: 100vh;
+			margin: 0;
 		}
 	}
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
https://payexjira.atlassian.net/browse/SWED-2268

- add a button in the DS documentation website to offer the user the possibility to expand the preview container to full-screen
- this is an opt-in feature added to the preview component. It is disabled by default. And, for start, is only enabled for the Topbar component. We can iterate on it later on. But working on the topbar as the next new big UI change it was making a lot of sense


## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

- specific tests have not been added (yet?)
- all old tests are passing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots
![Screenshot 2023-09-01 at 11 32 51](https://github.com/SwedbankPay/design.swedbankpay.com/assets/15030804/811bbf49-1802-409d-8666-db47ed1daad5)

![Screenshot 2023-09-01 at 11 33 49](https://github.com/SwedbankPay/design.swedbankpay.com/assets/15030804/8a092618-df95-44ea-bdcc-1ccb62e8756a)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [ ] Bug fix (non-breaking change which fixes an issue)
-   [x] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [x] I have updated the **CHANGELOG** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Review instructions

[Review instructions](../REVIEW_INSTRUCTIONS.md)
