### PR TITLE
SWED-2390 fix style tooltips position bug

### DIFF
--- a/src/less/components/tooltip.less
+++ b/src/less/components/tooltip.less
@@ -1,11 +1,14 @@
 .tooltip {
+	position: relative;
+	cursor: pointer;
+
 	&:hover {
-		border-color: @brand-secondary;
+		border-color: var(--brand-secondary);
 	}
 
 	&:focus-visible,
 	&:active {
-		outline: 2px solid @brand-secondary;
+		outline: 2px solid var(--brand-secondary);
 	}
 
 	&.isVisible {
@@ -41,8 +44,8 @@
 		max-width: 250px;
 		top: -8px;
 		transform: translateX(-50%) translateY(-100%);
-		background: @white;
-		color: @brand-secondary;
+		background: var(--white);
+		color: var(--brand-secondary);
 		text-align: center;
 		font-size: 0.875rem;
 		line-height: 1.5;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- a bug was introduced in 10.7.0 when we refactored the tooltips.less style files
- the tooltip was positioned not corresponding to its parent element anymore
- this was due to the `position: relative` removed from the parent `.tooltip` element during the refactor
- this PR is reverting it


## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [ ] I have updated the **CHANGELOG** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Review instructions

[Review instructions](../REVIEW_INSTRUCTIONS.md)
