### PR TITLE
PFE-6: Added input-border-disabled-color and changed success border c…

### DIFF
--- a/src/less/components/payex/form.less
+++ b/src/less/components/payex/form.less
@@ -3,3 +3,53 @@
 .help-block {
 	color: @help-block-text;
 }
+
+
+.form-group {
+	&.disabled,
+	[disabled] {
+		color: @brand-secondary-light-3;
+
+		.input-group-addon {
+			border-color: var(--input-border-disabled-color);
+			color: var(--text-disabled);
+
+			i {
+				color: var(--text-disabled);
+			}
+		}
+
+		input::placeholder {
+			color: var(--text-disabled);
+		}
+
+		&.form-control {
+			border-color: var(--input-border-disabled-color);
+		}
+
+		label {
+			color: var(--text-disabled);
+		}
+	}
+
+	&.has-success {
+		.form-control {
+			border-color: var(--input-border-success-color);
+		}
+
+		.input-group-addon,
+		.input-group-addon.postfix {
+			border-color: var(--input-border-success-color);
+		}
+
+		i {
+			color: var(--input-border-success-color);
+		}
+
+		&:focus-within {
+			.form-control {
+				border-color: var(--input-border-focus-color);
+			}
+		}
+	}
+}

--- a/src/less/components/payex/form.less
+++ b/src/less/components/payex/form.less
@@ -8,7 +8,7 @@
 .form-group {
 	&.disabled,
 	[disabled] {
-		color: --brand-secondary-light-3;
+		color: var(--brand-secondary-light-3);
 
 		.input-group-addon {
 			border-color: var(--input-border-disabled-color);

--- a/src/less/components/payex/form.less
+++ b/src/less/components/payex/form.less
@@ -8,7 +8,7 @@
 .form-group {
 	&.disabled,
 	[disabled] {
-		color: @brand-secondary-light-3;
+		color: --brand-secondary-light-3;
 
 		.input-group-addon {
 			border-color: var(--input-border-disabled-color);

--- a/src/less/variables-payex.less
+++ b/src/less/variables-payex.less
@@ -250,7 +250,8 @@ body {
 	--input-addon-color: var(--brand-secondary, #3c3c3c);
 	--input-border-color: var(--brand-secondary-hover, #5f5f5f);
 	--input-border-focus-color: var(--brand-secondary, #3c3c3c);
-	--input-border-success-color: var(--payex-light-blue);
+	--input-border-success-color: var(--brand-success);
+	--input-border-disabled-color: var(--brand-secondary-light-3, #c8c8c8);
 
 	/* Panel */
 	--panel-default-border-color: var(--brand-secondary-light-3, #c8c8c8);


### PR DESCRIPTION
## Description

PayEx success border color was wrong. Needed to be updated.

## Motivation and Context

Colors for PayEx input-border-color-success  and disabled did not exist and the current color scheme was wrong and needed to be updated.

## How Has This Been Tested?

Snapshot on input component with success and disabled, style lint for less files. Visual review sent to designer.

## Screenshots (if appropriate):
![image](https://github.com/SwedbankPay/design.swedbankpay.com/assets/18302805/bbb24ed2-37f7-4f50-a7bc-c04160235905)

![image](https://github.com/SwedbankPay/design.swedbankpay.com/assets/18302805/5b5a054b-183e-4292-9fc4-6086f06c4a4f)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [ ] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [ ] I have updated the **CHANGELOG** document.
-   [ ] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Review instructions

[Review instructions](../REVIEW_INSTRUCTIONS.md)
