### PR TITLE
Release 10.12.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@swedbankpay/design-guide",
-	"version": "10.12.0",
+	"version": "10.12.1",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@swedbankpay/design-guide",
-			"version": "10.12.0",
+			"version": "10.12.1",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@swedbankpay/design-guide",
-	"version": "10.12.0",
+	"version": "10.12.1",
 	"description": "Swedbank Pay Design Guide",
 	"main": "src/scripts/main/index.js",
 	"scripts": {

--- a/src/App/ComponentsDocumentation/__snapshots__/index.test.js.snap
+++ b/src/App/ComponentsDocumentation/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`ComponentsDocumentation: index renders 1`] = `
     className="dg-current-version text-uppercase"
   >
     Design Guide – v. 
-    10.12.0
+    10.12.1
   </span>
 </div>
 `;

--- a/src/App/Identity/__snapshots__/index.test.js.snap
+++ b/src/App/Identity/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`Core: index renders 1`] = `
     className="dg-current-version text-uppercase"
   >
     Design Guide – v. 
-    10.12.0
+    10.12.1
   </span>
 </div>
 `;

--- a/src/App/Patterns/__snapshots__/index.test.js.snap
+++ b/src/App/Patterns/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`Patterns: index renders 1`] = `
     className="dg-current-version text-uppercase"
   >
     Design Guide – v. 
-    10.12.0
+    10.12.1
   </span>
 </div>
 `;

--- a/src/App/Utilities/__snapshots__/index.test.js.snap
+++ b/src/App/Utilities/__snapshots__/index.test.js.snap
@@ -8,7 +8,7 @@ exports[`Utilities: index renders 1`] = `
     className="dg-current-version text-uppercase"
   >
     Design Guide - v. 
-    10.12.0
+    10.12.1
   </span>
   <div
     className="d-flex align-items-center"


### PR DESCRIPTION
# Changelog

## \[10.12.1\] - 21.06.2024

## Component changes

- Dialog

  - if no invoker or close btn JS fails gracefully, providing helpful feedback in the console instead of throwing Error
  - CSS support for old syntax now checks it is not picked up also by the new syntax (make sure not dialog.dialog)
  - new dialog can have multiple invokers

- Buttons

  - loading spinner of buttons keep their aspect-ratio even if the buttons is squashed, when they're in overflow state

- Cards

  - add support for div.illustration & picture elements in lieu of the img element as illustrations of used in the cards component (changes in documentation will come in a future release)
  - default cards wide with no img and no text content -> align-items: center (better default when title wraps)

- Dropdown

  - dropdown.init() method now accept `id` parameter to initialize specific dropdowns, instead of always all dropdowns found in the DOM

- Utility classes

  - Add utility classes for display grid and inline grid

## Technical changes

- chore deps (update deps packages minor versions)
