### PR TITLE
SWED-2505 Fixed issue where dropdown could not be initialized with ID

### DIFF
--- a/src/scripts/main/dropdown/index.js
+++ b/src/scripts/main/dropdown/index.js
@@ -56,17 +56,21 @@ const init = (id) => {
 	let dropdownMenu;
 
 	if (id) {
-		dropdownContainers = document?.getElementById(id);
+		/* Find the dropdown container by id, and wrap it in a NodeList like structure to 
+		avoid friction in the rest of the code */
+		const element = document.getElementById(id);
+		dropdownContainers = element ? [element] : [];
 
-		if (!dropdownContainers) {
+		if (!dropdownContainers.length) {
 			console.error(
 				`No dropdown found corresponding with the id provided in dropdown.init() passing this id value: "${id}"`,
 			);
 
 			return null;
 		}
-		dropdownToggles = dropdownContainers.querySelector(SELECTORS.TOGGLE);
-		dropdownMenu = dropdownContainers.querySelector(SELECTORS.DROPDOWNMENU);
+
+		dropdownToggles = element.querySelectorAll(SELECTORS.TOGGLE);
+		dropdownMenu = element.querySelectorAll(SELECTORS.DROPDOWNMENU);
 	} else {
 		dropdownContainers = document.querySelectorAll(SELECTORS.DROPDOWNLIST);
 		dropdownToggles = document.querySelectorAll(

--- a/src/scripts/main/dropdown/index.test.js
+++ b/src/scripts/main/dropdown/index.test.js
@@ -1,7 +1,6 @@
 import React from "react";
-import { render, screen } from "@testing-library/react";
+import { render } from "@testing-library/react";
 import "@testing-library/jest-dom";
-import userEvent from "@testing-library/user-event";
 
 import dropdown from "./index";
 
@@ -49,6 +48,24 @@ describe("Scripts: Dropdown", () => {
 
 			expect(dropdown.init()).toBeNull();
 			expect(console.warn).toHaveBeenCalled();
+		});
+
+		it("initializes with ID", () => {
+			render(<Dropdown id="foo" />);
+
+			console.warn = jest.fn();
+
+			expect(dropdown.init("foo")).not.toBeNull();
+			expect(console.warn).not.toHaveBeenCalled();
+		});
+
+		it("init returns null if no dropdown with ID is found and prints a warning message", () => {
+			render(<Dropdown id="foo" />);
+
+			console.error = jest.fn();
+
+			expect(dropdown.init("bar")).toBeNull();
+			expect(console.error).toHaveBeenCalled();
 		});
 	});
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The feature that was added where you could init a dropdown with an ID did not work. 
The change I made changed querySelectorAll to findById and querySelector, and because these only return a single element, it broke these conditionals:
```
if (!dropdownContainers.length) {
	console.warn("No dropdown container found");

	return null;
}

if (!dropdownToggles.length) {
	console.warn("No dropdown toggle button found");

	return null;
}

if (!dropdownMenu.length) {
	console.warn("No dropdown menu found");

	return null;
}
```

It also broke a forEach loop, but we returned null before we even got there. 

## Motivation and Context


## How Has This Been Tested?

I created two unit tests to test the issue, which basically just renders a dropdown component and makes sure it doesn't log any errors when initialized with ID, and also that it does log error when initialized with an ID that doesn't exist. 

## Screenshots (if appropriate):

## Types of changes

-   [x] Bug fix (non-breaking change which fixes an issue)
-   [ ] New feature (non-breaking change which adds functionality)
-   [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

-   [x] My code follows the code style of this project.
-   [ ] My change requires a change to the documentation.
-   [ ] I have updated the documentation accordingly.
-   [x] I have read the **CONTRIBUTING** document.
-   [ ] I have updated the **CHANGELOG** document.
-   [x] I have added tests to cover my changes.
-   [x] All new and existing tests passed.

## Review instructions

[Review instructions](../REVIEW_INSTRUCTIONS.md)
