### PR TITLE
Release 10.13.2

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,24 +1,5 @@
 # Changelog
 
-## \[10.13.1\] - 10.01.2025
+## \[10.13.2\] - 31.03.2025
 
-## Playbook
-
-- Updates to the playbook:
-
-## Identity
-
-- Updates the zip file containing the SwedbankPay logos with the new fixed versions
-
-## PayEx side UI changes
-
-- checkmark circle green color on success alerts is updated
-
-## Technical changes
-
-- Browser support got significantly increased (now last 2 major versions, Firefox ESR, > 0,5% instead of 1%).
-  - This is only impacting projects consuming the CSS & JS straight from the CDN. If you're pulling the source files then the polyfilling/transpilling will only be done by your own build pipeline anyways.
-
-## Chores
-
-- updated dependencies
+Hot fix for the Atlas CDN being down. We're now installing atlas cions locally, and modifying the way it's imported.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@swedbankpay/design-guide",
-	"version": "10.13.1",
+	"version": "10.13.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@swedbankpay/design-guide",
-			"version": "10.13.1",
+			"version": "10.13.2",
 			"hasInstallScript": true,
 			"license": "MIT",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
 			"dependencies": {
 				"@codesandbox/sandpack-react": "^1.20.7",
 				"@typescript-eslint/experimental-utils": "^5.62.0",
+				"@vectopus/atlas-icons": "^0.0.7",
 				"chalk": "^4.1.2",
 				"chart.js": "^2.9.4",
 				"classnames": "^2.5.1",
@@ -5378,6 +5379,12 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
 			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+		},
+		"node_modules/@vectopus/atlas-icons": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/@vectopus/atlas-icons/-/atlas-icons-0.0.7.tgz",
+			"integrity": "sha512-ojiDP0YpVbkEguQHzGnfOMXYaUysx7IWoD1qqOHbj/ebm9IuKlhSuSuXvNxWn3n7QahV66BZov8rwKNO7Yv/JQ==",
+			"license": "ISC"
 		},
 		"node_modules/@webassemblyjs/ast": {
 			"version": "1.12.1",
@@ -22808,6 +22815,11 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
 			"integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ=="
+		},
+		"@vectopus/atlas-icons": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/@vectopus/atlas-icons/-/atlas-icons-0.0.7.tgz",
+			"integrity": "sha512-ojiDP0YpVbkEguQHzGnfOMXYaUysx7IWoD1qqOHbj/ebm9IuKlhSuSuXvNxWn3n7QahV66BZov8rwKNO7Yv/JQ=="
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.12.1",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
 	"dependencies": {
 		"@codesandbox/sandpack-react": "^1.20.7",
 		"@typescript-eslint/experimental-utils": "^5.62.0",
+		"@vectopus/atlas-icons": "^0.0.7",
 		"chalk": "^4.1.2",
 		"chart.js": "^2.9.4",
 		"classnames": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@swedbankpay/design-guide",
-	"version": "10.13.1",
+	"version": "10.13.2",
 	"description": "Swedbank Pay Design Guide",
 	"main": "src/scripts/main/index.js",
 	"scripts": {

--- a/src/less/global.less
+++ b/src/less/global.less
@@ -3,8 +3,7 @@
 @import (css)
 	url("https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined");
 
-/* stylelint-disable-next-line import-notation */
-@import url("https://unpkg.com/@vectopus/atlas-icons/style.css");
+@import url("/node_modules/@vectopus/atlas-icons/style.css");
 
 /* Other colors */
 @text-muted: fade(@text-color, 75%);

--- a/src/less/global.less
+++ b/src/less/global.less
@@ -3,6 +3,7 @@
 @import (css)
 	url("https://fonts.googleapis.com/icon?family=Material+Icons|Material+Icons+Outlined");
 
+/* stylelint-disable-next-line import-notation */
 @import url("/node_modules/@vectopus/atlas-icons/style.css");
 
 /* Other colors */


### PR DESCRIPTION
# Changelog

## \[10.13.2\] - 31.03.2025

Hot fix for the Atlas CDN being down. We're now installing atlas icons locally, and modifying the way it's imported.
