### PR TITLE
Add 'gl' to iconography.less country codes

### DIFF
--- a/src/less/core/iconography.less
+++ b/src/less/core/iconography.less
@@ -364,6 +364,7 @@ i.flag-icon {
 	~"eu",
 	~"fi",
 	~"gb",
+	~"gl",
 	~"is",
 	~"lt",
 	~"lv",


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Will allow the use of the Greenland flag without importing the full flag list.

<!--- Describe your changes in detail -->

## Motivation and Context

This is required for sales portal to render the flags properly, in filters etc.
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
